### PR TITLE
chore(deps): upgrade oxy to ^0.1.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  ht:
+    dependency: transitive
+    description:
+      name: ht
+      sha256: f0d7413cb63e471d989e551b8eb05496fdec5a1c7596e5177669b1cf717882f1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -201,14 +209,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  ocookie:
+    dependency: transitive
+    description:
+      name: ocookie
+      sha256: b3dd5f8abe623e13a4ca88f0de90dd3309fca3b70652eff1a3a11a648ee20edb
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   oxy:
     dependency: "direct dev"
     description:
       name: oxy
-      sha256: "00f89b18c9559196f9c057008b0173af2e6d8f77f28bc401c20afb160b7f812b"
+      sha256: "577b4972e0e1095e2b3925c7017e3e2df79a6143c7ae463d5b855de63774c8af"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.4"
+    version: "0.1.0"
   package_config:
     dependency: transitive
     description:
@@ -426,4 +442,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.2 <4.0.0"
+  dart: ">=3.10.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,5 +16,5 @@ dependencies:
 dev_dependencies:
   benchmark_harness: ^2.3.1
   lints: ^6.0.0
-  oxy: ^0.0.4
+  oxy: ^0.1.0
   test: ^1.25.6


### PR DESCRIPTION
## Summary
- upgrade `oxy` in `dev_dependencies` from `^0.0.4` to `^0.1.0`
- refresh lockfile for the new resolution (`ht`/`ocookie` via `oxy`)

## Why
`coal` tests use `oxy` directly (`test/utils/text_width_test.dart`) for remote emoji fixture fetching, so this keeps the test stack aligned with the latest `oxy` release.

## Validation
- `dart pub get`
- `dart test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to incorporate improvements and stability enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->