### PR TITLE
feat(readline): add interactive input handling module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ A suite for easily building beautiful command-line apps.
 | [`package:coal/args.dart`](#args-parser) | ✅ | Provides command-line argument parsing functionality. |
 | [`package:coal/utils.dart`](#ansi-utility) | ✅ | Provides utility functions for ANSI escape codes and text manipulation. |
 | [`package:coal/tab.dart`](#tab) | 🚧 | Provides shell command completion and command-line app adapters. |
+| [`package:coal/readline.dart`](#readline) | ✅ | Provides interactive line-input helpers. |
 
 ## Roadmap
 
 - [x] [Args: Command-line argument parsing](#args-parser)
 - [x] [Utils: ANSI utility functions](#ansi-utility)
 - [ ] Keypass: Key input binding
-- [ ] Readline: Input handling
+- [x] [Readline: Input handling](#readline)
 - [ ] Prompt: Basic prompt process support and CLI frame handling
 - [ ] Prompt Utils: Advanced commonly used prompt utilities
 - [x] [Tab: Shell command autocompletion](#core)
@@ -63,6 +64,17 @@ There is a simple TAB demo → [\<TAB\> example](example/README.md#tab)
 > Thanks to [Cobra](https://github.com/spf13/cobra)! for the script and some of the <TAB> implementation references!
 
 <TAB> completion functionality
+
+## Readline
+
+Coal readline provides a lightweight input helper for interactive terminal flows:
+
+```dart
+import 'package:coal/readline.dart';
+
+final readline = Readline();
+final name = readline.readRequired(prompt: 'Name: ');
+```
 
 ## Args Parser
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Coal readline provides a lightweight input helper for interactive terminal flows
 ```dart
 import 'package:coal/readline.dart';
 
-final readline = Readline();
+final readline = Readline.stdio();
 final name = readline.readRequired(prompt: 'Name: ');
 ```
 

--- a/lib/readline.dart
+++ b/lib/readline.dart
@@ -1,0 +1,1 @@
+export 'src/readline/readline.dart';

--- a/lib/src/readline/readline.dart
+++ b/lib/src/readline/readline.dart
@@ -12,6 +12,9 @@ class Readline {
       _writer = writer ?? stdout.write,
       encoding = encoding ?? systemEncoding;
 
+  /// Creates a readline instance wired to process stdio.
+  Readline.stdio({Encoding? encoding}) : this(encoding: encoding);
+
   final ReadlineReader _reader;
   final ReadlineWriter _writer;
   final Encoding encoding;

--- a/lib/src/readline/readline.dart
+++ b/lib/src/readline/readline.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+import 'dart:io';
+
+typedef ReadlineReader =
+    String? Function({Encoding encoding, bool retainNewlines});
+typedef ReadlineWriter = void Function(Object? object);
+
+/// Lightweight input handler for interactive terminal prompts.
+class Readline {
+  Readline({ReadlineReader? reader, ReadlineWriter? writer, Encoding? encoding})
+    : _reader = reader ?? stdin.readLineSync,
+      _writer = writer ?? stdout.write,
+      encoding = encoding ?? systemEncoding;
+
+  final ReadlineReader _reader;
+  final ReadlineWriter _writer;
+  final Encoding encoding;
+
+  /// Reads one line from stdin.
+  ///
+  /// When [prompt] is set, it is written before reading input.
+  /// Returns `null` when stdin is closed.
+  String? read({
+    String prompt = '',
+    bool trim = true,
+    bool retainNewlines = false,
+  }) {
+    if (prompt.isNotEmpty) _writer(prompt);
+    final value = _reader(encoding: encoding, retainNewlines: retainNewlines);
+    if (value == null) return null;
+    return trim ? value.trim() : value;
+  }
+
+  /// Reads input until a non-empty value is entered.
+  ///
+  /// Throws [StateError] when stdin closes before any valid value is read.
+  String readRequired({
+    String prompt = '',
+    String? retryPrompt,
+    bool trim = true,
+    bool allowEmpty = false,
+  }) {
+    var activePrompt = prompt;
+    while (true) {
+      final value = read(prompt: activePrompt, trim: trim);
+      if (value == null) {
+        throw StateError('stdin closed while waiting for input');
+      }
+      if (allowEmpty || value.isNotEmpty) return value;
+      if (retryPrompt != null && retryPrompt.isNotEmpty) {
+        activePrompt = retryPrompt;
+      }
+    }
+  }
+}

--- a/test/readline_test.dart
+++ b/test/readline_test.dart
@@ -1,10 +1,21 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:coal/readline.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('readline', () {
+    test('stdio shortcut uses process stdio defaults', () {
+      final readline = Readline.stdio();
+      expect(readline.encoding, systemEncoding);
+    });
+
+    test('stdio shortcut allows overriding encoding', () {
+      final readline = Readline.stdio(encoding: utf8);
+      expect(readline.encoding, utf8);
+    });
+
     test('prints prompt and trims input by default', () {
       final writes = <Object?>[];
       final readline = Readline(

--- a/test/readline_test.dart
+++ b/test/readline_test.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+
+import 'package:coal/readline.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('readline', () {
+    test('prints prompt and trims input by default', () {
+      final writes = <Object?>[];
+      final readline = Readline(
+        writer: writes.add,
+        reader: ({Encoding encoding = utf8, bool retainNewlines = false}) {
+          expect(encoding, utf8);
+          expect(retainNewlines, isFalse);
+          return '  value  ';
+        },
+        encoding: utf8,
+      );
+
+      final value = readline.read(prompt: 'name: ');
+
+      expect(value, 'value');
+      expect(writes, <Object?>['name: ']);
+    });
+
+    test('can keep surrounding spaces when trim is disabled', () {
+      final readline = Readline(
+        reader: ({Encoding encoding = utf8, bool retainNewlines = false}) =>
+            '  value  ',
+      );
+
+      final value = readline.read(trim: false);
+
+      expect(value, '  value  ');
+    });
+
+    test('returns null when stdin is closed', () {
+      final readline = Readline(
+        writer: (_) {},
+        reader: ({Encoding encoding = utf8, bool retainNewlines = false}) =>
+            null,
+      );
+
+      final value = readline.read(prompt: '> ');
+
+      expect(value, isNull);
+    });
+
+    test('readRequired retries until non-empty input is provided', () {
+      final writes = <Object?>[];
+      final queue = <String?>['', '  ', 'coal'];
+      final readline = Readline(
+        writer: writes.add,
+        reader: ({Encoding encoding = utf8, bool retainNewlines = false}) {
+          return queue.removeAt(0);
+        },
+      );
+
+      final value = readline.readRequired(
+        prompt: 'first: ',
+        retryPrompt: 'again: ',
+      );
+
+      expect(value, 'coal');
+      expect(writes, <Object?>['first: ', 'again: ', 'again: ']);
+    });
+
+    test('readRequired throws when stdin closes before a valid value', () {
+      final readline = Readline(
+        writer: (_) {},
+        reader: ({Encoding encoding = utf8, bool retainNewlines = false}) =>
+            null,
+      );
+
+      expect(
+        () => readline.readRequired(prompt: 'value: '),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('readRequired can allow empty values', () {
+      final readline = Readline(
+        reader: ({Encoding encoding = utf8, bool retainNewlines = false}) => '',
+      );
+
+      final value = readline.readRequired(allowEmpty: true);
+
+      expect(value, '');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add new `package:coal/readline.dart` entrypoint with a lightweight `Readline` API
- support prompt writing, line reading, required-value loops, EOF handling, and injected IO for tests
- add unit tests for trimming behavior, retry logic, null input, and required mode
- mark roadmap Readline item as complete in README and add module documentation snippet

Closes #13
