### PR TITLE
feat: complete coal cli and terminal input primitives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
   dart:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk:
+          - 3.9.2
+          - stable
 
     steps:
       - name: Checkout
@@ -23,6 +29,8 @@ jobs:
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ matrix.sdk }}
 
       - name: Install Dependencies
         run: dart pub get
@@ -35,3 +43,16 @@ jobs:
 
       - name: Run Tests
         run: dart test --exclude-tags=script-runtime
+
+      - name: Run Example Smoke Tests
+        run: |
+          dart run example/tab.dart complete bash | bash -n
+          dart compile exe example/tab.dart --output=/tmp/coal-tab-example
+          /tmp/coal-tab-example complete bash | bash -n
+          dart run example/args_example.dart complete bash | bash -n
+
+      - name: Run Benchmark Smoke Test
+        run: dart run bench/args.dart
+
+      - name: Package Publish Dry Run
+        run: dart pub publish --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.0.7 - 2026-06-17
 
+- feat(readline): add line buffer, history, and editing core
 - feat(keypass): add key input decoding and binding dispatch primitives
 - feat(cli): add a narrow Coal CLI with doctor and Dart completion script commands
 - docs: define the supported module boundary and release readiness gates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.0.7 - 2026-06-17
 
+- feat(cli): add a narrow Coal CLI with doctor and Dart completion script commands
 - docs: define the supported module boundary and release readiness gates
 - docs: fix args and `package:args` adapter examples
 - fix(args): preserve dotted sibling values and stable default typed access

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.0.7 - 2026-06-17
+
+- docs: define the supported module boundary and release readiness gates
+- docs: fix args and `package:args` adapter examples
+- fix(args): preserve dotted sibling values and stable default typed access
+- fix(tab): sanitize shell helper names for command names with special characters
+- fix(tab): repair the source and compiled TAB example setup path
+- fix(utils): correct horizontal scroll escape sequences
+- ci: add example smoke, benchmark smoke, and publish dry-run gates
+- test: declare runtime tags and remove network-backed emoji test dependency
+- chore(deps): remove unused `oxy` dev dependency
+
 ## 0.0.6 - 2026-02-06
 
 - fix(tab): harden completion behavior and add regression tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.0.7 - 2026-06-17
 
+- feat(keypass): add key input decoding and binding dispatch primitives
 - feat(cli): add a narrow Coal CLI with doctor and Dart completion script commands
 - docs: define the supported module boundary and release readiness gates
 - docs: fix args and `package:args` adapter examples

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ keypass.addString('\u0003'); // ctrl+c
 keypass.addString('\u001b[A'); // up arrow
 ```
 
+Printable input is emitted as `TextInput`. Unsupported terminal control
+sequences are emitted as `ControlSequenceInput`, so they can be ignored without
+leaking escape fragments into editable text.
+
 `KeyParser` and `KeyDispatcher` are available separately when an app wants to
 own terminal mode, buffering, or line editing itself.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ improve existing CLI packages and hand-rolled command-line tools.
 | Entry | Status | Description |
 |:----:|:----:|:----|
 | [`package:coal/args.dart`](#args-parser) | Supported | Lightweight command-line argument parsing. |
+| [`package:coal/keypass.dart`](#keypass) | Supported | Key decoding, parsing, and binding dispatch primitives. |
 | [`package:coal/utils.dart`](#ansi-utility) | Supported | ANSI escape code, text width, wrapping, and styling utilities. |
 | [`package:coal/tab.dart`](#tab) | Supported | Shell completion definitions and script generation. |
 | [`package:coal/tab/args.dart`](example/README.md#args-adapter) | Supported | Completion adapter for `package:args` `CommandRunner` apps. |
@@ -71,6 +72,25 @@ There is a simple TAB demo → [\<TAB\> example](example/README.md#tab)
 The `package:coal/tab/args.dart` adapter can register completion definitions
 from a `package:args` `CommandRunner` app. See the
 [`args` adapter example](example/README.md#args-adapter).
+
+## Keypass
+
+Coal's Keypass module decodes terminal key bytes into text input and key events,
+then dispatches normalized key bindings:
+
+```dart
+import 'package:coal/keypass.dart';
+
+final keypass = Keypass()
+  ..bind('ctrl+c', (event) => print('cancel'))
+  ..bind('up', (event) => print('history up'));
+
+keypass.addString('\u0003'); // ctrl+c
+keypass.addString('\u001b[A'); // up arrow
+```
+
+`KeyParser` and `KeyDispatcher` are available separately when an app wants to
+own terminal mode, buffering, or line editing itself.
 
 ## Args Parser
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ improve existing CLI packages and hand-rolled command-line tools.
 | [`package:coal/tab.dart`](#tab) | Supported | Shell completion definitions and script generation. |
 | [`package:coal/tab/args.dart`](example/README.md#args-adapter) | Supported | Completion adapter for `package:args` `CommandRunner` apps. |
 
+## CLI
+
+Coal includes a small maintenance CLI:
+
+```bash
+dart pub global activate coal
+coal doctor
+coal complete bash
+coal dart-complete bash
+```
+
+`coal dart-complete <shell>` prints a completion script for the Dart CLI.
+Source it the same way as other shell completion scripts.
+
 ## Roadmap
 
 Coal's current plan is to stabilize the supported modules before expanding

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ keypass.addString('\u001b[A'); // up arrow
 
 Printable input is emitted as `TextInput`. Unsupported terminal control
 sequences are emitted as `ControlSequenceInput`, so they can be ignored without
-leaking escape fragments into editable text.
+leaking escape fragments into editable text. Bindings are for `KeyEvent`
+values; use `ctrl+a` or `meta+a` for chords, and handle plain `a` as text.
 
 `KeyParser` and `KeyDispatcher` are available separately when an app wants to
 own terminal mode, buffering, or line editing itself.

--- a/README.md
+++ b/README.md
@@ -1,38 +1,28 @@
 # Coal
 
-A suite for easily building beautiful command-line apps.
+A focused utility suite for building polished Dart command-line apps.
 
-> [!WARNING]
-> **Coal is still in development and may not be fully functional.**
->
-> Coal is not a CLI framework! It's intended to provide convenient and easy-to-use utilities for existing CLI frameworks and developers.
->
-> **Coal also doesn't plan to add command functionality. Its purpose is to enhance existing CLI packages.**
+Coal is not a CLI framework. It provides small, composable utilities that
+improve existing CLI packages and hand-rolled command-line tools.
 
 ## Modules
 
 | Entry | Status | Description |
 |:----:|:----:|:----|
-| [`package:coal/args.dart`](#args-parser) | ✅ | Provides command-line argument parsing functionality. |
-| [`package:coal/utils.dart`](#ansi-utility) | ✅ | Provides utility functions for ANSI escape codes and text manipulation. |
-| [`package:coal/tab.dart`](#tab) | 🚧 | Provides shell command completion and command-line app adapters. |
+| [`package:coal/args.dart`](#args-parser) | Supported | Lightweight command-line argument parsing. |
+| [`package:coal/utils.dart`](#ansi-utility) | Supported | ANSI escape code, text width, wrapping, and styling utilities. |
+| [`package:coal/tab.dart`](#tab) | Supported | Shell completion definitions and script generation. |
+| [`package:coal/tab/args.dart`](example/README.md#args-adapter) | Supported | Completion adapter for `package:args` `CommandRunner` apps. |
 
 ## Roadmap
 
-- [x] [Args: Command-line argument parsing](#args-parser)
-- [x] [Utils: ANSI utility functions](#ansi-utility)
-- [ ] Keypass: Key input binding
-- [ ] Readline: Input handling
-- [ ] Prompt: Basic prompt process support and CLI frame handling
-- [ ] Prompt Utils: Advanced commonly used prompt utilities
-- [x] [Tab: Shell command autocompletion](#core)
-- [x] [Tab Adapters: Tab completion adapters for popular Dart CLI packages](example/README.md#args-adapter)
-- [ ] Dart CLI setup: Add completion to `dart` command
-
+Coal's current plan is to stabilize the supported modules before expanding
+into new terminal interaction areas. See [doc/roadmap.md](doc/roadmap.md)
+for the release goal, deferred product areas, and readiness gates.
 
 ## Installation
 
-To install the Coal suite, run the following command:
+Install the package with Dart:
 
 ```bash
 dart pub add coal
@@ -47,6 +37,8 @@ dart pub add coal
 Coal's core \<TAB\> completion implementation allows you to add completion functionality to any Dart command-line app:
 
 ```dart
+import 'package:coal/tab.dart';
+
 final tab = Tab();
 final complete = tab.command('complete', '<TAB> autocompletion');
 
@@ -62,17 +54,27 @@ There is a simple TAB demo → [\<TAB\> example](example/README.md#tab)
 
 > Thanks to [Cobra](https://github.com/spf13/cobra)! for the script and some of the <TAB> implementation references!
 
-<TAB> completion functionality
+The `package:coal/tab/args.dart` adapter can register completion definitions
+from a `package:args` `CommandRunner` app. See the
+[`args` adapter example](example/README.md#args-adapter).
 
 ## Args Parser
 
-Coal provides a powerful argument parser that allows you to define and parse command-line arguments easily:
+Coal provides a lightweight parser for scripts and custom CLI plumbing:
 
 ```dart
 import 'package:coal/args.dart';
 
-const input = ['--a=1','-b','--bool','--no-boop','--multi=foo','--multi=baz','-xyz'];
-final args = Args.parse(input);
+const input = [
+  '--a=1',
+  '-b',
+  '--bool',
+  '--no-boop',
+  '--multi=foo',
+  '--multi=baz',
+  '-xyz',
+];
+final args = Args.parse(input, list: ['multi']);
 
 print(args.toJson());
 ```
@@ -88,9 +90,6 @@ print(args.toJson());
   "z": true
 }
 ```
-
-> [!WARNING]
-> Coal is currently under development and documentation is not yet ready.
 
 ## ANSI Utility
 
@@ -124,7 +123,7 @@ Coal provides a series of convenient utilities for generating ANSI escape codes:
 | `cursorHide` | Hide the cursor. |
 | `cursorSave` | Save the cursor position. |
 | `cursorRestore` | Restore the cursor position. |
-| `cursorLeft` | Move the cursor left by one column. |
+| `cursorLeft` | Move the cursor to the first column. |
 
 ### Erase
 
@@ -158,10 +157,19 @@ Coal provides a series of convenient utilities for generating ANSI escape codes:
 #### Style Text
 
 ```dart
-// Dart SDK >= 3.10.0
-final text = styleText('Hello, World!', [.red]);
-// <= 3.10.0
 final text = styleText('Hello, World!', [TextStyle.red]);
+```
+
+## Development
+
+Before publishing or merging release-oriented changes, run:
+
+```bash
+dart format --output=none --set-exit-if-changed .
+dart analyze
+dart test --exclude-tags=script-runtime
+dart test --tags=script-runtime
+dart pub publish --dry-run
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ improve existing CLI packages and hand-rolled command-line tools.
 |:----:|:----:|:----|
 | [`package:coal/args.dart`](#args-parser) | Supported | Lightweight command-line argument parsing. |
 | [`package:coal/keypass.dart`](#keypass) | Supported | Key decoding, parsing, and binding dispatch primitives. |
+| [`package:coal/readline.dart`](#readline) | Supported | Readline-style line buffer, history, and editing state. |
 | [`package:coal/utils.dart`](#ansi-utility) | Supported | ANSI escape code, text width, wrapping, and styling utilities. |
 | [`package:coal/tab.dart`](#tab) | Supported | Shell completion definitions and script generation. |
 | [`package:coal/tab/args.dart`](example/README.md#args-adapter) | Supported | Completion adapter for `package:args` `CommandRunner` apps. |
@@ -91,6 +92,28 @@ keypass.addString('\u001b[A'); // up arrow
 
 `KeyParser` and `KeyDispatcher` are available separately when an app wants to
 own terminal mode, buffering, or line editing itself.
+
+## Readline
+
+Coal's Readline module provides the editable line state used by interactive
+terminal flows:
+
+```dart
+import 'package:coal/keypass.dart';
+import 'package:coal/readline.dart';
+
+final editor = LineEditor();
+final parser = KeyParser();
+
+for (final input in parser.addString('co\u001b[D!')) {
+  editor.apply(input);
+}
+
+print(editor.text); // c!o
+```
+
+It intentionally does not own stdin, raw mode, or prompt rendering. Those
+remain application responsibilities or future higher-level modules.
 
 ## Args Parser
 

--- a/bin/coal.dart
+++ b/bin/coal.dart
@@ -1,0 +1,7 @@
+import 'dart:io';
+
+import 'package:coal/src/cli/cli.dart';
+
+Future<void> main(List<String> args) async {
+  exitCode = await runCoal(args);
+}

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,3 @@
+tags:
+  script-runtime:
+    timeout: 2x

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -9,7 +9,7 @@ and easy to test without a real terminal unless the feature truly needs one.
 | Layer | Modules | Rule |
 | --- | --- | --- |
 | Core | Args, Utils, Tab | Supported now. Keep API stable and dependency-light. |
-| Terminal input | Keypass, Readline | Build only the primitives needed for real terminal input. |
+| Terminal input | Keypass, Readline | Keypass is supported; Readline should build on it without global side effects. |
 | Prompt | Prompt, Prompt Utils | Build on Keypass/Readline after their contracts are clear. |
 | Coal CLI | `coal` executable | Only maintenance/setup commands, not a general app framework. |
 
@@ -21,6 +21,7 @@ and easy to test without a real terminal unless the feature truly needs one.
 | Utils | `package:coal/utils.dart` | Supported | ANSI escape helpers, VT stripping, text width, wrapping, and styling. |
 | Tab | `package:coal/tab.dart` | Supported | Completion definitions and shell script generation for Bash, Zsh, Fish, and PowerShell. |
 | Args adapter | `package:coal/tab/args.dart` | Supported | Completion wiring for `package:args` `CommandRunner` apps. |
+| Keypass | `package:coal/keypass.dart` | Supported | Terminal key decoding, stateful byte parsing, and binding dispatch without owning stdin. |
 
 ## Issue Map
 
@@ -28,7 +29,7 @@ and easy to test without a real terminal unless the feature truly needs one.
 | --- | --- |
 | #11 Tab maintenance docs | Implement as a short maintainer guide. |
 | #16 Dart CLI completion setup | Implement through the Coal CLI. Start with script generation before shell-specific install automation. |
-| #12 Keypass | Rebuild as a small key event decoder and binding dispatcher. No global raw-mode side effects in the core API. |
+| #12 Keypass | Implemented as small key decoding, stateful parsing, and binding dispatch primitives. No raw-mode or stdin ownership in the core API. |
 | #13 Readline | Do not merge the old `stdin.readLineSync` wrapper as "readline". A real slice needs cursor editing, history, and tests built on Keypass. |
 | #14 Prompt | Defer until Readline has a stable editing contract. |
 | #15 Prompt Utils | Defer until Prompt exists; utilities must prove repeated real use. |

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -1,13 +1,19 @@
-# Coal Roadmap
+# Coal Shape
 
-Coal is a small Dart package for CLI utility layers, not a command framework.
-The planning boundary is intentionally narrow: keep the current package useful
-for existing CLI applications before adding new product areas.
+Coal is a small Dart toolkit for building Dart CLIs. It is not a command
+framework. Each module must stay independently useful, small enough to audit,
+and easy to test without a real terminal unless the feature truly needs one.
 
-## Real-Use Baseline
+## Layers
 
-Coal is considered usable when these modules are documented, tested, and
-publishable together:
+| Layer | Modules | Rule |
+| --- | --- | --- |
+| Core | Args, Utils, Tab | Supported now. Keep API stable and dependency-light. |
+| Terminal input | Keypass, Readline | Build only the primitives needed for real terminal input. |
+| Prompt | Prompt, Prompt Utils | Build on Keypass/Readline after their contracts are clear. |
+| Coal CLI | `coal` executable | Only maintenance/setup commands, not a general app framework. |
+
+## Current Public Surface
 
 | Module | Public entrypoint | Status | Supported use |
 | --- | --- | --- | --- |
@@ -16,33 +22,32 @@ publishable together:
 | Tab | `package:coal/tab.dart` | Supported | Completion definitions and shell script generation for Bash, Zsh, Fish, and PowerShell. |
 | Args adapter | `package:coal/tab/args.dart` | Supported | Completion wiring for `package:args` `CommandRunner` apps. |
 
-## Current Release Goal
+## Issue Map
 
-The next usable release should focus on stability rather than breadth:
-
-1. Keep public entrypoints small and explicit.
-2. Keep shell completion scripts synced with the tracked Cobra release.
-3. Keep generated examples reproducible from source instead of checked in as
-   binaries.
-4. Keep CI green for format, analysis, unit tests, tab contract tests, and
-   publish dry-run.
-5. Document every public module in the README and examples.
-
-## Deferred Product Areas
-
-These areas remain outside the current package contract until they have a
-separate design and test plan:
-
-| Area | Decision |
+| Issue | Decision |
 | --- | --- |
-| Key input binding | Defer. It needs terminal mode handling and cross-platform input tests. |
-| Readline | Defer. It overlaps with line editing, history, signals, and terminal state. |
-| Prompt flows | Defer. It should not be added until Coal has a clear frame-rendering model. |
-| Dart CLI setup automation | Defer. Completion for `dart run` and compiled executables needs a precise install story. |
+| #11 Tab maintenance docs | Implement as a short maintainer guide. |
+| #16 Dart CLI completion setup | Implement through the Coal CLI. Start with script generation before shell-specific install automation. |
+| #12 Keypass | Rebuild as a small key event decoder and binding dispatcher. No global raw-mode side effects in the core API. |
+| #13 Readline | Do not merge the old `stdin.readLineSync` wrapper as "readline". A real slice needs cursor editing, history, and tests built on Keypass. |
+| #14 Prompt | Defer until Readline has a stable editing contract. |
+| #15 Prompt Utils | Defer until Prompt exists; utilities must prove repeated real use. |
+| #2 Dependency dashboard | Keep Renovate-managed; no product work unless dependencies are stale or blocking. |
+
+## Coal CLI
+
+The `coal` executable should stay narrow:
+
+- `coal complete <shell>` prints completion for the `coal` executable.
+- `coal dart-complete <shell>` prints completion for the `dart` command.
+- `coal doctor` reports local shell support for completion/runtime tests.
+
+It should not create project scaffolds, own command routing for user apps, or
+duplicate package managers.
 
 ## Readiness Gates
 
-Run these commands before publishing or merging a release-oriented change:
+Run these before publishing or merging release-oriented changes:
 
 ```bash
 dart format --output=none --set-exit-if-changed .
@@ -51,3 +56,7 @@ dart test --exclude-tags=script-runtime
 dart test --tags=script-runtime
 dart pub publish --dry-run
 ```
+
+Feature slices need focused tests at their layer boundary. Do not add a module
+without a public entrypoint, README/example coverage, and regression tests for
+the terminal behavior it claims to support.

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -9,7 +9,7 @@ and easy to test without a real terminal unless the feature truly needs one.
 | Layer | Modules | Rule |
 | --- | --- | --- |
 | Core | Args, Utils, Tab | Supported now. Keep API stable and dependency-light. |
-| Terminal input | Keypass, Readline | Keypass is supported; Readline should build on it without global side effects. |
+| Terminal input | Keypass, Readline | Supported as small parsing and editing primitives without global side effects. |
 | Prompt | Prompt, Prompt Utils | Build on Keypass/Readline after their contracts are clear. |
 | Coal CLI | `coal` executable | Only maintenance/setup commands, not a general app framework. |
 
@@ -22,6 +22,7 @@ and easy to test without a real terminal unless the feature truly needs one.
 | Tab | `package:coal/tab.dart` | Supported | Completion definitions and shell script generation for Bash, Zsh, Fish, and PowerShell. |
 | Args adapter | `package:coal/tab/args.dart` | Supported | Completion wiring for `package:args` `CommandRunner` apps. |
 | Keypass | `package:coal/keypass.dart` | Supported | Terminal key decoding, stateful byte parsing, and binding dispatch without owning stdin. |
+| Readline | `package:coal/readline.dart` | Supported | Line buffer, cursor editing, history navigation, and Keypass input application without owning stdin. |
 
 ## Issue Map
 
@@ -30,7 +31,7 @@ and easy to test without a real terminal unless the feature truly needs one.
 | #11 Tab maintenance docs | Implement as a short maintainer guide. |
 | #16 Dart CLI completion setup | Implement through the Coal CLI. Start with script generation before shell-specific install automation. |
 | #12 Keypass | Implemented as small key decoding, stateful parsing, and binding dispatch primitives. No raw-mode or stdin ownership in the core API. |
-| #13 Readline | Do not merge the old `stdin.readLineSync` wrapper as "readline". A real slice needs cursor editing, history, and tests built on Keypass. |
+| #13 Readline | Implemented as a testable line editing core built on Keypass input types. No stdin/raw-mode ownership. |
 | #14 Prompt | Defer until Readline has a stable editing contract. |
 | #15 Prompt Utils | Defer until Prompt exists; utilities must prove repeated real use. |
 | #2 Dependency dashboard | Keep Renovate-managed; no product work unless dependencies are stale or blocking. |

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -1,0 +1,53 @@
+# Coal Roadmap
+
+Coal is a small Dart package for CLI utility layers, not a command framework.
+The planning boundary is intentionally narrow: keep the current package useful
+for existing CLI applications before adding new product areas.
+
+## Real-Use Baseline
+
+Coal is considered usable when these modules are documented, tested, and
+publishable together:
+
+| Module | Public entrypoint | Status | Supported use |
+| --- | --- | --- | --- |
+| Args | `package:coal/args.dart` | Supported | Lightweight parsing for scripts and custom CLI plumbing. |
+| Utils | `package:coal/utils.dart` | Supported | ANSI escape helpers, VT stripping, text width, wrapping, and styling. |
+| Tab | `package:coal/tab.dart` | Supported | Completion definitions and shell script generation for Bash, Zsh, Fish, and PowerShell. |
+| Args adapter | `package:coal/tab/args.dart` | Supported | Completion wiring for `package:args` `CommandRunner` apps. |
+
+## Current Release Goal
+
+The next usable release should focus on stability rather than breadth:
+
+1. Keep public entrypoints small and explicit.
+2. Keep shell completion scripts synced with the tracked Cobra release.
+3. Keep generated examples reproducible from source instead of checked in as
+   binaries.
+4. Keep CI green for format, analysis, unit tests, tab contract tests, and
+   publish dry-run.
+5. Document every public module in the README and examples.
+
+## Deferred Product Areas
+
+These areas remain outside the current package contract until they have a
+separate design and test plan:
+
+| Area | Decision |
+| --- | --- |
+| Key input binding | Defer. It needs terminal mode handling and cross-platform input tests. |
+| Readline | Defer. It overlaps with line editing, history, signals, and terminal state. |
+| Prompt flows | Defer. It should not be added until Coal has a clear frame-rendering model. |
+| Dart CLI setup automation | Defer. Completion for `dart run` and compiled executables needs a precise install story. |
+
+## Readiness Gates
+
+Run these commands before publishing or merging a release-oriented change:
+
+```bash
+dart format --output=none --set-exit-if-changed .
+dart analyze
+dart test --exclude-tags=script-runtime
+dart test --tags=script-runtime
+dart pub publish --dry-run
+```

--- a/doc/tab-maintenance.md
+++ b/doc/tab-maintenance.md
@@ -1,0 +1,29 @@
+# Tab Maintenance
+
+Coal's shell completion templates are adapted from released Cobra sources.
+Only sync from upstream release tags, not from main or development branches.
+
+## Sync Steps
+
+1. Compare the tracked Cobra release in `lib/src/tab/scripts/*.dart` with the
+   latest upstream Cobra release.
+2. Port only relevant changes into the Dart script generators.
+3. Update each script file's upstream metadata comment.
+4. Run the validation commands below.
+
+## Validation
+
+```bash
+dart format --output=none --set-exit-if-changed .
+dart analyze
+dart test --exclude-tags=script-runtime test/tab
+COAL_REQUIRED_SHELLS=bash,zsh dart test --tags=script-runtime
+```
+
+Use `COAL_REQUIRED_SHELLS=bash,zsh,fish,pwsh` when all shells are installed.
+
+## CI
+
+- `.github/workflows/tab-contract.yml` checks deterministic script and parse contracts.
+- `.github/workflows/tab-script-runtime.yml` checks shell runtime behavior.
+- `.github/workflows/upstream-cobra-watch.yml` opens or updates the upstream watch issue.

--- a/example/README.md
+++ b/example/README.md
@@ -39,16 +39,16 @@ tab <TAB>
 dart compile exe args_example.dart --output=args_example
 
 # bash
-source <(tab args_example bash)
+source <(args_example complete bash)
 
 # zsh
-source <(tab args_example zsh)
+source <(args_example complete zsh)
 
 # fish, Remember to delete it after you finish your experience!
-tab args_example fish > ~/.config/fish/completions/args_example.fish
+args_example complete fish > ~/.config/fish/completions/args_example.fish
 
 # powershell
-tab args_example powershell > ~/.args_example-completion.ps1
+args_example complete powershell > ~/.args_example-completion.ps1
 echo '. ~/.args_example-completion.ps1' > $PROFILE
 ```
 

--- a/example/tab.dart
+++ b/example/tab.dart
@@ -26,13 +26,22 @@ void main(List<String> input) {
       final args = input.skip(2);
       return tab.parse(args);
     } else {
-      return tab.setup(
-        'dart tab.dart',
-        'dart ${Platform.script.toFilePath()}',
-        shell,
-      );
+      final (name, exec) = resolveExecInfo();
+      return tab.setup(name, exec, shell);
     }
   }
 
   print(input);
+}
+
+(String, String) resolveExecInfo() {
+  final script = Platform.script.toFilePath();
+  final exec = Platform.resolvedExecutable;
+  final scriptName = script.split(Platform.pathSeparator).last;
+  final name = scriptName.endsWith('.dart')
+      ? scriptName.substring(0, scriptName.length - '.dart'.length)
+      : scriptName;
+
+  if (script == exec) return (name, script);
+  return (name, 'dart $script');
 }

--- a/lib/coal.dart
+++ b/lib/coal.dart
@@ -1,4 +1,5 @@
 export 'args.dart';
 export 'keypass.dart';
+export 'readline.dart';
 export 'tab.dart';
 export 'utils.dart';

--- a/lib/coal.dart
+++ b/lib/coal.dart
@@ -1,1 +1,3 @@
-export 'utils.dart' show TextStyle, styleText;
+export 'args.dart';
+export 'tab.dart';
+export 'utils.dart';

--- a/lib/coal.dart
+++ b/lib/coal.dart
@@ -1,3 +1,4 @@
 export 'args.dart';
+export 'keypass.dart';
 export 'tab.dart';
 export 'utils.dart';

--- a/lib/keypass.dart
+++ b/lib/keypass.dart
@@ -1,4 +1,10 @@
-export 'src/keypass/decoder.dart';
-export 'src/keypass/dispatcher.dart';
-export 'src/keypass/event.dart';
-export 'src/keypass/keypass.dart';
+export 'src/keypass/decoder.dart' show KeyDecoder, KeyParser;
+export 'src/keypass/dispatcher.dart' show KeyBindingHandler, KeyDispatcher;
+export 'src/keypass/event.dart'
+    show
+        ControlSequenceInput,
+        KeyEvent,
+        KeyInput,
+        TextInput,
+        normalizeKeyBinding;
+export 'src/keypass/keypass.dart' show Keypass;

--- a/lib/keypass.dart
+++ b/lib/keypass.dart
@@ -1,0 +1,4 @@
+export 'src/keypass/decoder.dart';
+export 'src/keypass/dispatcher.dart';
+export 'src/keypass/event.dart';
+export 'src/keypass/keypass.dart';

--- a/lib/readline.dart
+++ b/lib/readline.dart
@@ -1,0 +1,3 @@
+export 'src/readline/editor.dart';
+export 'src/readline/history.dart';
+export 'src/readline/line_buffer.dart';

--- a/lib/src/args/_utils.dart
+++ b/lib/src/args/_utils.dart
@@ -20,14 +20,11 @@ void dotNestedSet<T>(
   ValueType? type,
 ]) {
   if (key.contains('.')) {
-    final parts = key.split('.'), last = parts.last;
-    for (final part in parts) {
-      if (part == last) break;
-      final nested = Argv(<String, Argv>{});
-      dotNestedSet(argv, part, nested);
-      argv = nested;
+    final parts = key.split('.');
+    for (final part in parts.take(parts.length - 1)) {
+      argv = nestedArgv(argv, part);
     }
-    key = last;
+    key = parts.last;
   }
 
   if (type == ValueType.list && argv.value.containsKey(key)) {
@@ -41,6 +38,17 @@ void dotNestedSet<T>(
   } else {
     argv.value[key] = Argv(value);
   }
+}
+
+Argv<Map<String, Argv>> nestedArgv(Argv<Map<String, Argv>> argv, String key) {
+  final current = argv.value[key];
+  if (current?.value case final Map<String, Argv> value) {
+    return Argv(value);
+  }
+
+  final nested = Argv(<String, Argv>{});
+  argv.value[key] = nested;
+  return nested;
 }
 
 ValueType? typeof(String key, Map<ValueType, Iterable<String>> types) {

--- a/lib/src/args/args.dart
+++ b/lib/src/args/args.dart
@@ -85,7 +85,7 @@ Args _parse(
   final wrappedDefaults = defaults != null && defaults.isNotEmpty
       ? wrapDefaults(defaults)
       : <String, Argv>{};
-  if (input.isEmpty) return _ArgsImpl(wrapDefaults(wrappedDefaults));
+  if (input.isEmpty) return _ArgsImpl(wrappedDefaults);
   final rest = <String>[],
       coerceRest = [],
       args = _ArgsImpl(wrappedDefaults, rest, coerceRest),

--- a/lib/src/cli/cli.dart
+++ b/lib/src/cli/cli.dart
@@ -141,7 +141,9 @@ class DartCompleteCommand extends Command {
       orElse: () =>
           throw UsageException('Unsupported shell: $shellName', usage),
     );
-    _out.writeln(shell.generate('dart', 'coal dart-complete', backend: '--'));
+    _out.writeln(
+      shell.generate('dart', 'coal dart-complete', completionCommand: '--'),
+    );
     return 0;
   }
 }

--- a/lib/src/cli/cli.dart
+++ b/lib/src/cli/cli.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:coal/tab.dart' as coal;
+
+import 'dart_completion.dart';
+
+CommandRunner buildCoalCommandRunner({
+  StringSink? out,
+  bool Function(String command)? hasCommand,
+}) {
+  final runner =
+      CommandRunner(
+          'coal',
+          'Utilities for building polished Dart command-line apps.',
+        )
+        ..addCommand(CoalCompleteCommand(out: out))
+        ..addCommand(DartCompleteCommand(out: out))
+        ..addCommand(DoctorCommand(out: out, hasCommand: hasCommand));
+  return runner;
+}
+
+Future<int> runCoal(
+  List<String> args, {
+  StringSink? out,
+  StringSink? err,
+  bool Function(String command)? hasCommand,
+}) async {
+  final stdoutSink = out ?? stdout;
+  final stderrSink = err ?? stderr;
+  final runner = buildCoalCommandRunner(
+    out: stdoutSink,
+    hasCommand: hasCommand,
+  );
+
+  return runZoned(
+    () async {
+      try {
+        final result = await runner.run(args);
+        return result is int ? result : 0;
+      } on UsageException catch (error) {
+        stderrSink.writeln(error);
+        return 64;
+      }
+    },
+    zoneSpecification: ZoneSpecification(
+      print: (_, _, _, line) => stdoutSink.writeln(line),
+    ),
+  );
+}
+
+coal.Tab buildCoalCompletion() {
+  final tab = coal.Tab();
+
+  tab.command('doctor', 'Check local shell support used by Coal');
+  tab
+      .command('dart-complete', 'Generate completion for the Dart CLI')
+      .argument('shell', _completeShells);
+  tab
+      .command('complete', 'Generate completion for the Coal CLI')
+      .argument('shell', _completeShells);
+
+  return tab;
+}
+
+void _completeShells(coal.Complete complete, Map<String, coal.Option> options) {
+  for (final shell in coal.Shell.values) {
+    complete(shell.name, 'Generate ${shell.name} completion');
+  }
+}
+
+class CoalCompleteCommand extends Command {
+  CoalCompleteCommand({StringSink? out}) : _out = out ?? stdout;
+
+  final StringSink _out;
+
+  @override
+  String get name => 'complete';
+
+  @override
+  String get description => 'Generate completion for the Coal CLI.';
+
+  @override
+  String get invocation =>
+      'coal complete <${coal.Shell.values.map((shell) => shell.name).join('|')}>';
+
+  @override
+  int run() {
+    final args = argResults?.arguments ?? const <String>[];
+    if (args.firstOrNull == '--') {
+      buildCoalCompletion().parse(args.skip(1));
+      return 0;
+    }
+
+    final shellName = args.firstOrNull;
+    if (shellName == null) {
+      throw UsageException('Missing shell name.', usage);
+    }
+
+    final shell = coal.Shell.values.firstWhere(
+      (shell) => shell.name == shellName.trim().toLowerCase(),
+      orElse: () =>
+          throw UsageException('Unsupported shell: $shellName', usage),
+    );
+    _out.writeln(shell.generate('coal', 'coal'));
+    return 0;
+  }
+}
+
+class DartCompleteCommand extends Command {
+  DartCompleteCommand({StringSink? out}) : _out = out ?? stdout;
+
+  final StringSink _out;
+
+  @override
+  String get name => 'dart-complete';
+
+  @override
+  String get description => 'Generate completion for the Dart CLI.';
+
+  @override
+  String get invocation =>
+      'coal dart-complete <${coal.Shell.values.map((shell) => shell.name).join('|')}>';
+
+  @override
+  int run() {
+    final args = argResults?.arguments ?? const <String>[];
+    if (args.firstOrNull == '--') {
+      buildDartCompletion().parse(args.skip(1));
+      return 0;
+    }
+
+    final shellName = args.firstOrNull;
+    if (shellName == null) {
+      throw UsageException('Missing shell name.', usage);
+    }
+
+    final shell = coal.Shell.values.firstWhere(
+      (shell) => shell.name == shellName.trim().toLowerCase(),
+      orElse: () =>
+          throw UsageException('Unsupported shell: $shellName', usage),
+    );
+    _out.writeln(shell.generate('dart', 'coal dart-complete', backend: '--'));
+    return 0;
+  }
+}
+
+class DoctorCommand extends Command {
+  DoctorCommand({StringSink? out, bool Function(String command)? hasCommand})
+    : _out = out ?? stdout,
+      _hasCommand = hasCommand ?? _defaultHasCommand;
+
+  final StringSink _out;
+  final bool Function(String command) _hasCommand;
+
+  @override
+  String get name => 'doctor';
+
+  @override
+  String get description => 'Check local shell support used by Coal.';
+
+  @override
+  int run() {
+    final shells = <String>['bash', 'zsh', 'fish', 'pwsh'];
+    for (final shell in shells) {
+      final status = _hasCommand(shell) ? 'ok' : 'missing';
+      _out.writeln('$shell: $status');
+    }
+    return 0;
+  }
+}
+
+bool _defaultHasCommand(String command) {
+  final lookup = Platform.isWindows ? 'where' : 'which';
+  final result = Process.runSync(lookup, [command]);
+  return result.exitCode == 0;
+}

--- a/lib/src/cli/dart_completion.dart
+++ b/lib/src/cli/dart_completion.dart
@@ -1,0 +1,95 @@
+import 'package:coal/tab.dart';
+
+Tab buildDartCompletion() {
+  final tab = Tab();
+
+  tab
+    ..option('help', 'Print usage information', null, alias: 'h')
+    ..option('verbose', 'Show additional command output', null, alias: 'v')
+    ..option('version', 'Print the Dart SDK version', null)
+    ..option('enable-analytics', 'Enable analytics', null)
+    ..option('disable-analytics', 'Disable analytics', null)
+    ..option('suppress-analytics', 'Disable analytics for this run', null);
+
+  for (final command in _commands) {
+    final def = tab.command(command.name, command.description);
+    for (final option in command.options) {
+      def.option(option.name, option.description, null);
+    }
+
+    for (final value in command.values) {
+      tab.command('${command.name} $value', value);
+    }
+  }
+
+  return tab;
+}
+
+class _DartCommandSpec {
+  const _DartCommandSpec(
+    this.name,
+    this.description, {
+    this.options = const <_DartOptionSpec>[],
+    this.values = const <String>[],
+  });
+
+  final String name;
+  final String description;
+  final List<_DartOptionSpec> options;
+  final List<String> values;
+}
+
+class _DartOptionSpec {
+  const _DartOptionSpec(this.name, this.description);
+
+  final String name;
+  final String description;
+}
+
+const _commands = <_DartCommandSpec>[
+  _DartCommandSpec('install', 'Install or upgrade a global Dart CLI tool'),
+  _DartCommandSpec('installed', 'List globally installed Dart CLI tools'),
+  _DartCommandSpec('uninstall', 'Remove a globally installed Dart CLI tool'),
+  _DartCommandSpec('build', 'Build a Dart application'),
+  _DartCommandSpec(
+    'compile',
+    'Compile Dart to self-contained outputs',
+    values: <String>['exe', 'aot-snapshot', 'jit-snapshot', 'js', 'kernel'],
+  ),
+  _DartCommandSpec('create', 'Create a new Dart project'),
+  _DartCommandSpec(
+    'pub',
+    'Work with packages',
+    values: <String>[
+      'add',
+      'cache',
+      'deps',
+      'downgrade',
+      'get',
+      'global',
+      'login',
+      'logout',
+      'outdated',
+      'publish',
+      'remove',
+      'token',
+      'unpack',
+      'upgrade',
+    ],
+  ),
+  _DartCommandSpec(
+    'run',
+    'Run a Dart program',
+    options: <_DartOptionSpec>[
+      _DartOptionSpec('observe', 'Enable observatory'),
+      _DartOptionSpec('enable-asserts', 'Enable assert statements'),
+    ],
+  ),
+  _DartCommandSpec('test', 'Run tests for a project'),
+  _DartCommandSpec('analyze', 'Analyze Dart code'),
+  _DartCommandSpec('doc', 'Generate API documentation'),
+  _DartCommandSpec('fix', 'Apply automated fixes'),
+  _DartCommandSpec('format', 'Format Dart source code'),
+  _DartCommandSpec('devtools', 'Open Dart DevTools'),
+  _DartCommandSpec('info', 'Show Dart diagnostic information'),
+];

--- a/lib/src/keypass/decoder.dart
+++ b/lib/src/keypass/decoder.dart
@@ -1,0 +1,390 @@
+import 'dart:convert';
+
+import 'package:characters/characters.dart';
+
+import 'event.dart';
+
+/// Decodes complete terminal key sequences.
+abstract final class KeyDecoder {
+  static KeyInput decodeSequence(String sequence) {
+    final input = tryDecodeSequence(sequence);
+    if (input == null) {
+      throw FormatException('Unsupported key sequence: $sequence');
+    }
+    return input;
+  }
+
+  static KeyInput? tryDecodeSequence(String sequence) {
+    if (sequence.isEmpty) {
+      throw FormatException('Key sequence cannot be empty.');
+    }
+
+    if (sequence.codeUnitAt(0) != _escape) {
+      if (sequence.length == 1 && isAsciiControl(sequence.codeUnitAt(0))) {
+        return _decodeControl(sequence);
+      }
+      return TextInput(sequence);
+    }
+
+    if (sequence == _escapeChar) {
+      return KeyEvent('escape', sequence: sequence);
+    }
+
+    final csi = _decodeCsi(sequence);
+    if (csi != null) return csi;
+
+    final ss3 = _decodeSs3(sequence);
+    if (ss3 != null) return ss3;
+
+    final nested = tryDecodeSequence(sequence.substring(1));
+    if (nested is KeyEvent) {
+      return nested.copyWith(meta: true, sequence: sequence);
+    }
+    if (nested is TextInput) {
+      final event = _eventFromText(nested.text, sequence: sequence);
+      if (event == null) return null;
+      return event.copyWith(meta: true, sequence: sequence);
+    }
+
+    return null;
+  }
+}
+
+/// Stateful byte parser for terminal input.
+final class KeyParser {
+  KeyParser({Encoding encoding = utf8}) : _stringSink = _DecodedStringSink() {
+    _byteSink = encoding.decoder.startChunkedConversion(_stringSink);
+  }
+
+  final _DecodedStringSink _stringSink;
+  late final Sink<List<int>> _byteSink;
+  var _pending = '';
+  var _closed = false;
+
+  List<KeyInput> addBytes(List<int> bytes) {
+    if (_closed) throw StateError('Cannot add bytes after close().');
+    _byteSink.add(bytes);
+    return addString(_stringSink.take());
+  }
+
+  List<KeyInput> addString(String input) {
+    if (_closed) throw StateError('Cannot add input after close().');
+    if (input.isEmpty) return const <KeyInput>[];
+    _pending += input;
+    return _drain(flush: false);
+  }
+
+  /// Emits pending ambiguous key prefixes such as a lone escape byte.
+  List<KeyInput> flush() {
+    return _drain(flush: true);
+  }
+
+  /// Closes the UTF-8 byte decoder and emits any pending key prefix.
+  List<KeyInput> close() {
+    if (!_closed) {
+      _byteSink.close();
+      _closed = true;
+      _pending += _stringSink.take();
+    }
+    return _drain(flush: true);
+  }
+
+  List<KeyInput> _drain({required bool flush}) {
+    final inputs = <KeyInput>[];
+
+    while (_pending.isNotEmpty) {
+      final input = _takeNext(flush: flush);
+      if (input == null) break;
+      inputs.add(input);
+    }
+
+    return inputs;
+  }
+
+  KeyInput? _takeNext({required bool flush}) {
+    final first = _pending.codeUnitAt(0);
+
+    if (first == _escape) {
+      return _takeEscape(flush: flush);
+    }
+
+    if (isAsciiControl(first)) {
+      final sequence = _pending.substring(0, 1);
+      _pending = _pending.substring(1);
+      return KeyDecoder.decodeSequence(sequence);
+    }
+
+    var end = 1;
+    while (end < _pending.length) {
+      final unit = _pending.codeUnitAt(end);
+      if (unit == _escape || isAsciiControl(unit)) break;
+      end++;
+    }
+
+    final text = _pending.substring(0, end);
+    _pending = _pending.substring(end);
+    return TextInput(text);
+  }
+
+  KeyInput? _takeEscape({required bool flush}) {
+    if (_pending.length == 1) {
+      if (!flush) return null;
+      _pending = '';
+      return KeyEvent('escape', sequence: _escapeChar);
+    }
+
+    final second = _pending.codeUnitAt(1);
+    if (second == _csiStart) {
+      final end = _findCsiEnd(_pending);
+      if (end == null) {
+        if (!flush) return null;
+        _pending = _pending.substring(1);
+        return KeyEvent('escape', sequence: _escapeChar);
+      }
+
+      final sequence = _pending.substring(0, end + 1);
+      final decoded = KeyDecoder.tryDecodeSequence(sequence);
+      if (decoded != null) {
+        _pending = _pending.substring(end + 1);
+        return decoded;
+      }
+
+      _pending = _pending.substring(1);
+      return KeyEvent('escape', sequence: _escapeChar);
+    }
+
+    if (second == _ss3Start) {
+      if (_pending.length < 3) {
+        if (!flush) return null;
+        _pending = _pending.substring(1);
+        return KeyEvent('escape', sequence: _escapeChar);
+      }
+
+      final sequence = _pending.substring(0, 3);
+      final decoded = KeyDecoder.tryDecodeSequence(sequence);
+      if (decoded != null) {
+        _pending = _pending.substring(3);
+        return decoded;
+      }
+
+      _pending = _pending.substring(1);
+      return KeyEvent('escape', sequence: _escapeChar);
+    }
+
+    final next = _pending.substring(1).characters.first;
+    final sequence = _pending.substring(0, next.length + 1);
+    final decoded = KeyDecoder.tryDecodeSequence(sequence);
+    if (decoded == null) {
+      _pending = _pending.substring(1);
+      return KeyEvent('escape', sequence: _escapeChar);
+    }
+
+    _pending = _pending.substring(sequence.length);
+    return decoded;
+  }
+}
+
+final class _DecodedStringSink extends StringConversionSinkBase {
+  final _chunks = StringBuffer();
+
+  @override
+  void add(String str) {
+    _chunks.write(str);
+  }
+
+  @override
+  void addSlice(String str, int start, int end, bool isLast) {
+    _chunks.write(str.substring(start, end));
+    if (isLast) close();
+  }
+
+  @override
+  void close() {}
+
+  String take() {
+    final value = _chunks.toString();
+    _chunks.clear();
+    return value;
+  }
+}
+
+final class _DecodedKey {
+  const _DecodedKey(this.key, {this.shift = false});
+
+  final String key;
+  final bool shift;
+
+  KeyEvent toEvent(String sequence) {
+    return KeyEvent(key, shift: shift, sequence: sequence);
+  }
+}
+
+KeyEvent _decodeControl(String sequence) {
+  final code = sequence.codeUnitAt(0);
+  final key = _controlKeyMap[code];
+  if (key != null) return KeyEvent(key, sequence: sequence);
+
+  if (code == 0) {
+    return KeyEvent('space', ctrl: true, sequence: sequence);
+  }
+  if (code >= 1 && code <= 26) {
+    return KeyEvent(
+      String.fromCharCode(code + 0x60),
+      ctrl: true,
+      sequence: sequence,
+    );
+  }
+
+  return KeyEvent('control-$code', ctrl: true, sequence: sequence);
+}
+
+KeyEvent? _decodeCsi(String sequence) {
+  if (!sequence.startsWith(_csiPrefix) || sequence.length < 3) return null;
+
+  final payload = sequence.substring(2);
+  final finalChar = payload.substring(payload.length - 1);
+  final finalUnit = finalChar.codeUnitAt(0);
+  if (!_isCsiFinal(finalUnit)) return null;
+
+  final paramsRaw = payload.substring(0, payload.length - 1);
+  if (paramsRaw.isNotEmpty && !RegExp(r'^[0-9;]+$').hasMatch(paramsRaw)) {
+    return null;
+  }
+
+  final params = <int>[];
+  for (final part in paramsRaw.split(';')) {
+    if (part.isEmpty) continue;
+    final value = int.tryParse(part);
+    if (value == null) return null;
+    params.add(value);
+  }
+
+  if (finalChar == '~') {
+    if (params.isEmpty) return null;
+    final key = _tildeKeyCodes[params.first];
+    if (key == null) return null;
+    final modifier = params.length > 1 ? params[1] : 1;
+    final flags = _decodeModifier(modifier);
+    return KeyEvent(
+      key,
+      ctrl: flags.ctrl,
+      meta: flags.meta,
+      shift: flags.shift,
+      sequence: sequence,
+    );
+  }
+
+  final base = _csiFinalMap[finalChar];
+  if (base == null) return null;
+
+  var modifier = 1;
+  if (params.length > 1) {
+    modifier = params[1];
+  } else if (params.length == 1 && params.first > 1) {
+    modifier = params.first;
+  }
+
+  final flags = _decodeModifier(modifier);
+  return KeyEvent(
+    base.key,
+    ctrl: flags.ctrl,
+    meta: flags.meta,
+    shift: base.shift || flags.shift,
+    sequence: sequence,
+  );
+}
+
+KeyEvent? _decodeSs3(String sequence) {
+  if (!sequence.startsWith(_ss3Prefix) || sequence.length != 3) return null;
+  return _ss3FinalMap[sequence.substring(2)]?.toEvent(sequence);
+}
+
+KeyEvent? _eventFromText(String text, {required String sequence}) {
+  if (text.characters.length != 1) return null;
+
+  final char = text.characters.first;
+  final unit = char.codeUnitAt(0);
+  final shift = unit >= 0x41 && unit <= 0x5a;
+  final key = switch (char) {
+    ' ' => 'space',
+    '+' => 'plus',
+    _ => shift ? char.toLowerCase() : char,
+  };
+
+  return KeyEvent(key, shift: shift, sequence: sequence);
+}
+
+({bool ctrl, bool meta, bool shift}) _decodeModifier(int value) {
+  if (value <= 1) return (ctrl: false, meta: false, shift: false);
+  final bits = value - 1;
+  return (ctrl: bits & 4 != 0, meta: bits & 2 != 0, shift: bits & 1 != 0);
+}
+
+int? _findCsiEnd(String input) {
+  for (var index = 2; index < input.length; index++) {
+    if (_isCsiFinal(input.codeUnitAt(index))) return index;
+  }
+  return null;
+}
+
+bool _isCsiFinal(int unit) => unit >= 0x40 && unit <= 0x7e;
+
+const _escape = 0x1b;
+const _csiStart = 0x5b;
+const _ss3Start = 0x4f;
+const _escapeChar = '\u001b';
+const _csiPrefix = '\u001b[';
+const _ss3Prefix = '\u001bO';
+
+const _controlKeyMap = <int, String>{
+  8: 'backspace',
+  9: 'tab',
+  10: 'enter',
+  13: 'enter',
+  27: 'escape',
+  127: 'backspace',
+};
+
+const _tildeKeyCodes = <int, String>{
+  1: 'home',
+  2: 'insert',
+  3: 'delete',
+  4: 'end',
+  5: 'pageup',
+  6: 'pagedown',
+  15: 'f5',
+  17: 'f6',
+  18: 'f7',
+  19: 'f8',
+  20: 'f9',
+  21: 'f10',
+  23: 'f11',
+  24: 'f12',
+};
+
+const _csiFinalMap = <String, _DecodedKey>{
+  'A': _DecodedKey('up'),
+  'B': _DecodedKey('down'),
+  'C': _DecodedKey('right'),
+  'D': _DecodedKey('left'),
+  'F': _DecodedKey('end'),
+  'H': _DecodedKey('home'),
+  'P': _DecodedKey('f1'),
+  'Q': _DecodedKey('f2'),
+  'R': _DecodedKey('f3'),
+  'S': _DecodedKey('f4'),
+  'Z': _DecodedKey('tab', shift: true),
+};
+
+const _ss3FinalMap = <String, _DecodedKey>{
+  'A': _DecodedKey('up'),
+  'B': _DecodedKey('down'),
+  'C': _DecodedKey('right'),
+  'D': _DecodedKey('left'),
+  'F': _DecodedKey('end'),
+  'H': _DecodedKey('home'),
+  'P': _DecodedKey('f1'),
+  'Q': _DecodedKey('f2'),
+  'R': _DecodedKey('f3'),
+  'S': _DecodedKey('f4'),
+};

--- a/lib/src/keypass/decoder.dart
+++ b/lib/src/keypass/decoder.dart
@@ -36,6 +36,17 @@ abstract final class KeyDecoder {
     final ss3 = _decodeSs3(sequence);
     if (ss3 != null) return ss3;
 
+    if (sequence.startsWith(_csiPrefix)) {
+      final end = _findCsiEnd(sequence);
+      if (end == sequence.length - 1) return ControlSequenceInput(sequence);
+      return null;
+    }
+
+    if (sequence.startsWith(_ss3Prefix)) {
+      if (sequence.length == 3) return ControlSequenceInput(sequence);
+      return null;
+    }
+
     final nested = tryDecodeSequence(sequence.substring(1));
     if (nested is KeyEvent) {
       return nested.copyWith(meta: true, sequence: sequence);
@@ -138,8 +149,9 @@ final class KeyParser {
       final end = _findCsiEnd(_pending);
       if (end == null) {
         if (!flush) return null;
-        _pending = _pending.substring(1);
-        return KeyEvent('escape', sequence: _escapeChar);
+        final sequence = _pending;
+        _pending = '';
+        return ControlSequenceInput(sequence);
       }
 
       final sequence = _pending.substring(0, end + 1);
@@ -149,15 +161,16 @@ final class KeyParser {
         return decoded;
       }
 
-      _pending = _pending.substring(1);
-      return KeyEvent('escape', sequence: _escapeChar);
+      _pending = _pending.substring(end + 1);
+      return ControlSequenceInput(sequence);
     }
 
     if (second == _ss3Start) {
       if (_pending.length < 3) {
         if (!flush) return null;
-        _pending = _pending.substring(1);
-        return KeyEvent('escape', sequence: _escapeChar);
+        final sequence = _pending;
+        _pending = '';
+        return ControlSequenceInput(sequence);
       }
 
       final sequence = _pending.substring(0, 3);
@@ -167,8 +180,8 @@ final class KeyParser {
         return decoded;
       }
 
-      _pending = _pending.substring(1);
-      return KeyEvent('escape', sequence: _escapeChar);
+      _pending = _pending.substring(3);
+      return ControlSequenceInput(sequence);
     }
 
     final next = _pending.substring(1).characters.first;

--- a/lib/src/keypass/dispatcher.dart
+++ b/lib/src/keypass/dispatcher.dart
@@ -21,6 +21,13 @@ final class KeyDispatcher {
 
   void bind(String binding, KeyBindingHandler handler, {bool replace = false}) {
     final normalized = normalizeKeyBinding(binding);
+    if (_isPlainTextBinding(normalized)) {
+      throw ArgumentError.value(
+        binding,
+        'binding',
+        'printable input is emitted as TextInput, not KeyEvent',
+      );
+    }
     final handlers = _bindings.putIfAbsent(
       normalized,
       () => <KeyBindingHandler>[],
@@ -59,4 +66,14 @@ final class KeyDispatcher {
   }
 
   void clear() => _bindings.clear();
+}
+
+bool _isPlainTextBinding(String binding) {
+  final parts = binding.split('+');
+  final key = parts.last;
+  final modifiers = parts.take(parts.length - 1).toSet();
+  final hasKeyModifier =
+      modifiers.contains('ctrl') || modifiers.contains('meta');
+  if (hasKeyModifier) return false;
+  return key == 'space' || key == 'plus' || key.length == 1;
 }

--- a/lib/src/keypass/dispatcher.dart
+++ b/lib/src/keypass/dispatcher.dart
@@ -1,0 +1,56 @@
+import 'event.dart';
+
+typedef KeyBindingHandler = void Function(KeyEvent event);
+
+/// Dispatches normalized key events to registered handlers.
+final class KeyDispatcher {
+  final _bindings = <String, List<KeyBindingHandler>>{};
+
+  int get bindingCount {
+    return _bindings.values.fold<int>(
+      0,
+      (count, handlers) => count + handlers.length,
+    );
+  }
+
+  void bind(String binding, KeyBindingHandler handler, {bool replace = false}) {
+    final normalized = normalizeKeyBinding(binding);
+    final handlers = _bindings.putIfAbsent(
+      normalized,
+      () => <KeyBindingHandler>[],
+    );
+    if (replace) handlers.clear();
+    handlers.add(handler);
+  }
+
+  bool unbind(String binding, [KeyBindingHandler? handler]) {
+    final normalized = normalizeKeyBinding(binding);
+    final handlers = _bindings[normalized];
+    if (handlers == null || handlers.isEmpty) return false;
+
+    if (handler == null) {
+      _bindings.remove(normalized);
+      return true;
+    }
+
+    final removed = handlers.remove(handler);
+    if (handlers.isEmpty) _bindings.remove(normalized);
+    return removed;
+  }
+
+  bool isBound(String binding) {
+    return _bindings[normalizeKeyBinding(binding)]?.isNotEmpty == true;
+  }
+
+  bool dispatch(KeyEvent event) {
+    final handlers = _bindings[event.binding];
+    if (handlers == null || handlers.isEmpty) return false;
+
+    for (final handler in List<KeyBindingHandler>.of(handlers)) {
+      handler(event);
+    }
+    return true;
+  }
+
+  void clear() => _bindings.clear();
+}

--- a/lib/src/keypass/dispatcher.dart
+++ b/lib/src/keypass/dispatcher.dart
@@ -3,10 +3,16 @@ import 'event.dart';
 typedef KeyBindingHandler = void Function(KeyEvent event);
 
 /// Dispatches normalized key events to registered handlers.
+///
+/// Printable input is decoded as [TextInput], not [KeyEvent], so it is not
+/// matched by this dispatcher. Consumers that need text should handle
+/// [TextInput] directly or use `package:coal/readline.dart`.
 final class KeyDispatcher {
   final _bindings = <String, List<KeyBindingHandler>>{};
 
-  int get bindingCount {
+  int get bindingCount => _bindings.length;
+
+  int get handlerCount {
     return _bindings.values.fold<int>(
       0,
       (count, handlers) => count + handlers.length,

--- a/lib/src/keypass/event.dart
+++ b/lib/src/keypass/event.dart
@@ -23,6 +23,24 @@ final class TextInput extends KeyInput {
   String toString() => 'TextInput($text)';
 }
 
+/// Unsupported terminal control sequence that should not be inserted as text.
+final class ControlSequenceInput extends KeyInput {
+  const ControlSequenceInput(this.sequence);
+
+  final String sequence;
+
+  @override
+  bool operator ==(Object other) {
+    return other is ControlSequenceInput && other.sequence == sequence;
+  }
+
+  @override
+  int get hashCode => sequence.hashCode;
+
+  @override
+  String toString() => 'ControlSequenceInput($sequence)';
+}
+
 /// Non-text key input such as arrows, enter, or control chords.
 final class KeyEvent extends KeyInput {
   KeyEvent(
@@ -80,8 +98,12 @@ String normalizeKeyBinding(String binding) {
   var shift = false;
   String? key;
 
-  for (final rawPart in source.split('+')) {
-    final part = rawPart.trim();
+  final rawParts = source.split('+');
+  for (final (index, rawPart) in rawParts.indexed) {
+    var part = rawPart.trim();
+    if (part.isEmpty && index == rawParts.length - 1 && source.endsWith('+')) {
+      part = '+';
+    }
     if (part.isEmpty) continue;
 
     final lower = part.toLowerCase();

--- a/lib/src/keypass/event.dart
+++ b/lib/src/keypass/event.dart
@@ -1,0 +1,165 @@
+import 'package:characters/characters.dart';
+
+/// Input decoded from terminal key bytes.
+sealed class KeyInput {
+  const KeyInput();
+}
+
+/// Printable text input.
+final class TextInput extends KeyInput {
+  const TextInput(this.text);
+
+  final String text;
+
+  @override
+  bool operator ==(Object other) {
+    return other is TextInput && other.text == text;
+  }
+
+  @override
+  int get hashCode => text.hashCode;
+
+  @override
+  String toString() => 'TextInput($text)';
+}
+
+/// Non-text key input such as arrows, enter, or control chords.
+final class KeyEvent extends KeyInput {
+  KeyEvent(
+    String key, {
+    this.ctrl = false,
+    this.meta = false,
+    this.shift = false,
+    this.sequence,
+  }) : key = normalizeKeyToken(key);
+
+  final String key;
+  final bool ctrl;
+  final bool meta;
+  final bool shift;
+  final String? sequence;
+
+  String get binding =>
+      composeKeyBinding(key: key, ctrl: ctrl, meta: meta, shift: shift);
+
+  bool matches(String binding) => normalizeKeyBinding(binding) == this.binding;
+
+  KeyEvent copyWith({bool? ctrl, bool? meta, bool? shift, String? sequence}) {
+    return KeyEvent(
+      key,
+      ctrl: ctrl ?? this.ctrl,
+      meta: meta ?? this.meta,
+      shift: shift ?? this.shift,
+      sequence: sequence ?? this.sequence,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is KeyEvent &&
+        other.key == key &&
+        other.ctrl == ctrl &&
+        other.meta == meta &&
+        other.shift == shift;
+  }
+
+  @override
+  int get hashCode => Object.hash(key, ctrl, meta, shift);
+
+  @override
+  String toString() => 'KeyEvent($binding)';
+}
+
+/// Normalizes a binding such as `Shift + Ctrl + A` to `ctrl+shift+a`.
+String normalizeKeyBinding(String binding) {
+  final source = binding.trim();
+  if (source.isEmpty) throw FormatException('Key binding cannot be empty.');
+
+  var ctrl = false;
+  var meta = false;
+  var shift = false;
+  String? key;
+
+  for (final rawPart in source.split('+')) {
+    final part = rawPart.trim();
+    if (part.isEmpty) continue;
+
+    final lower = part.toLowerCase();
+    switch (lower) {
+      case 'ctrl':
+      case 'control':
+      case 'ctl':
+        ctrl = true;
+      case 'meta':
+      case 'alt':
+      case 'option':
+      case 'command':
+      case 'cmd':
+        meta = true;
+      case 'shift':
+        shift = true;
+      default:
+        if (key != null) {
+          throw FormatException(
+            'Key binding must contain exactly one key token.',
+          );
+        }
+        if (part.characters.length == 1 && _isAsciiUpper(part.codeUnitAt(0))) {
+          shift = true;
+        }
+        key = normalizeKeyToken(lower);
+    }
+  }
+
+  if (key == null) {
+    throw FormatException('Key binding must contain a key token.');
+  }
+
+  return composeKeyBinding(key: key, ctrl: ctrl, meta: meta, shift: shift);
+}
+
+String composeKeyBinding({
+  required String key,
+  required bool ctrl,
+  required bool meta,
+  required bool shift,
+}) {
+  final parts = <String>[
+    if (ctrl) 'ctrl',
+    if (meta) 'meta',
+    if (shift) 'shift',
+    normalizeKeyToken(key),
+  ];
+  return parts.join('+');
+}
+
+String normalizeKeyToken(String key) {
+  final normalized = key.trim().toLowerCase();
+  if (normalized.isEmpty) {
+    throw FormatException('Key token cannot be empty.');
+  }
+
+  return switch (normalized) {
+    'esc' || 'escape' => 'escape',
+    'return' || 'enter' => 'enter',
+    'space' || 'spacebar' => 'space',
+    'pgup' || 'pageup' || 'page-up' => 'pageup',
+    'pgdown' || 'pagedown' || 'page-down' => 'pagedown',
+    'del' || 'delete' => 'delete',
+    'ins' || 'insert' => 'insert',
+    'arrowup' || 'up' => 'up',
+    'arrowdown' || 'down' => 'down',
+    'arrowleft' || 'left' => 'left',
+    'arrowright' || 'right' => 'right',
+    '+' || 'plus' => 'plus',
+    _ => normalized,
+  };
+}
+
+bool isAsciiControl(int codeUnit) {
+  return codeUnit < 0x20 || codeUnit == 0x7f;
+}
+
+bool _isAsciiUpper(int codeUnit) {
+  return codeUnit >= 0x41 && codeUnit <= 0x5a;
+}

--- a/lib/src/keypass/keypass.dart
+++ b/lib/src/keypass/keypass.dart
@@ -13,6 +13,8 @@ final class Keypass {
 
   int get bindingCount => dispatcher.bindingCount;
 
+  int get handlerCount => dispatcher.handlerCount;
+
   void bind(String binding, KeyBindingHandler handler, {bool replace = false}) {
     dispatcher.bind(binding, handler, replace: replace);
   }

--- a/lib/src/keypass/keypass.dart
+++ b/lib/src/keypass/keypass.dart
@@ -1,0 +1,52 @@
+import 'decoder.dart';
+import 'dispatcher.dart';
+import 'event.dart';
+
+/// Convenience facade that parses key bytes and dispatches key events.
+final class Keypass {
+  Keypass({KeyParser? parser, KeyDispatcher? dispatcher})
+    : parser = parser ?? KeyParser(),
+      dispatcher = dispatcher ?? KeyDispatcher();
+
+  final KeyParser parser;
+  final KeyDispatcher dispatcher;
+
+  int get bindingCount => dispatcher.bindingCount;
+
+  void bind(String binding, KeyBindingHandler handler, {bool replace = false}) {
+    dispatcher.bind(binding, handler, replace: replace);
+  }
+
+  bool unbind(String binding, [KeyBindingHandler? handler]) {
+    return dispatcher.unbind(binding, handler);
+  }
+
+  bool isBound(String binding) => dispatcher.isBound(binding);
+
+  bool dispatch(KeyEvent event) => dispatcher.dispatch(event);
+
+  List<KeyInput> addBytes(List<int> bytes) {
+    return _dispatchParsed(parser.addBytes(bytes));
+  }
+
+  List<KeyInput> addString(String input) {
+    return _dispatchParsed(parser.addString(input));
+  }
+
+  List<KeyInput> flush() {
+    return _dispatchParsed(parser.flush());
+  }
+
+  List<KeyInput> close() {
+    return _dispatchParsed(parser.close());
+  }
+
+  void clear() => dispatcher.clear();
+
+  List<KeyInput> _dispatchParsed(List<KeyInput> inputs) {
+    for (final input in inputs) {
+      if (input is KeyEvent) dispatcher.dispatch(input);
+    }
+    return inputs;
+  }
+}

--- a/lib/src/readline/editor.dart
+++ b/lib/src/readline/editor.dart
@@ -1,0 +1,164 @@
+import '../keypass/event.dart';
+import 'history.dart';
+import 'line_buffer.dart';
+
+enum LineEditAction { none, changed, submitted, canceled, eof }
+
+/// Result of applying one input to a [LineEditor].
+final class LineEditResult {
+  const LineEditResult(this.action, {this.value});
+
+  const LineEditResult.none() : this(LineEditAction.none);
+
+  const LineEditResult.changed(String value)
+    : this(LineEditAction.changed, value: value);
+
+  const LineEditResult.submitted(String value)
+    : this(LineEditAction.submitted, value: value);
+
+  const LineEditResult.canceled(String value)
+    : this(LineEditAction.canceled, value: value);
+
+  const LineEditResult.eof() : this(LineEditAction.eof);
+
+  final LineEditAction action;
+  final String? value;
+
+  bool get isTerminal {
+    return action == LineEditAction.submitted ||
+        action == LineEditAction.canceled ||
+        action == LineEditAction.eof;
+  }
+}
+
+/// Editing core for one readline-style input line.
+final class LineEditor {
+  LineEditor({LineBuffer? buffer, LineHistory? history})
+    : buffer = buffer ?? LineBuffer(),
+      history = history ?? LineHistory();
+
+  final LineBuffer buffer;
+  final LineHistory history;
+
+  int? _historyIndex;
+  var _historyDraft = '';
+
+  String get text => buffer.text;
+
+  int get cursor => buffer.cursor;
+
+  LineEditResult apply(KeyInput input) {
+    return switch (input) {
+      TextInput(:final text) => _insert(text),
+      KeyEvent() => _applyKey(input),
+    };
+  }
+
+  LineEditResult submit() {
+    final value = buffer.text;
+    history.add(value);
+    buffer.clear();
+    _resetHistoryCursor();
+    return LineEditResult.submitted(value);
+  }
+
+  LineEditResult cancel() {
+    final value = buffer.text;
+    buffer.clear();
+    _resetHistoryCursor();
+    return LineEditResult.canceled(value);
+  }
+
+  LineEditResult _insert(String text) {
+    _resetHistoryCursor();
+    return _changed(buffer.insert(text));
+  }
+
+  LineEditResult _applyKey(KeyEvent event) {
+    switch (event.binding) {
+      case 'enter':
+        return submit();
+      case 'ctrl+c':
+        return cancel();
+      case 'ctrl+d':
+        if (buffer.isEmpty) return const LineEditResult.eof();
+        _resetHistoryCursor();
+        return _changed(buffer.deleteForward());
+      case 'backspace':
+      case 'ctrl+h':
+        _resetHistoryCursor();
+        return _changed(buffer.deleteBackward());
+      case 'delete':
+        _resetHistoryCursor();
+        return _changed(buffer.deleteForward());
+      case 'left':
+      case 'ctrl+b':
+        return _changed(buffer.moveLeft());
+      case 'right':
+      case 'ctrl+f':
+        return _changed(buffer.moveRight());
+      case 'home':
+      case 'ctrl+a':
+        return _changed(buffer.moveToStart());
+      case 'end':
+      case 'ctrl+e':
+        return _changed(buffer.moveToEnd());
+      case 'ctrl+u':
+        _resetHistoryCursor();
+        return _changed(buffer.clearBeforeCursor());
+      case 'ctrl+k':
+        _resetHistoryCursor();
+        return _changed(buffer.clearAfterCursor());
+      case 'up':
+      case 'ctrl+p':
+        return _changed(_historyPrevious());
+      case 'down':
+      case 'ctrl+n':
+        return _changed(_historyNext());
+    }
+
+    return const LineEditResult.none();
+  }
+
+  LineEditResult _changed(bool changed) {
+    if (!changed) return const LineEditResult.none();
+    return LineEditResult.changed(buffer.text);
+  }
+
+  bool _historyPrevious() {
+    if (history.isEmpty) return false;
+
+    if (_historyIndex == null) {
+      _historyDraft = buffer.text;
+      _historyIndex = history.length - 1;
+    } else if (_historyIndex! > 0) {
+      _historyIndex = _historyIndex! - 1;
+    } else {
+      return false;
+    }
+
+    buffer.replace(history[_historyIndex!]);
+    return true;
+  }
+
+  bool _historyNext() {
+    final index = _historyIndex;
+    if (index == null) return false;
+
+    if (index < history.length - 1) {
+      _historyIndex = index + 1;
+      buffer.replace(history[_historyIndex!]);
+    } else {
+      _historyIndex = null;
+      buffer.replace(_historyDraft);
+      _historyDraft = '';
+    }
+
+    return true;
+  }
+
+  void _resetHistoryCursor() {
+    _historyIndex = null;
+    _historyDraft = '';
+  }
+}

--- a/lib/src/readline/editor.dart
+++ b/lib/src/readline/editor.dart
@@ -50,6 +50,7 @@ final class LineEditor {
   LineEditResult apply(KeyInput input) {
     return switch (input) {
       TextInput(:final text) => _insert(text),
+      ControlSequenceInput() => const LineEditResult.none(),
       KeyEvent() => _applyKey(input),
     };
   }

--- a/lib/src/readline/history.dart
+++ b/lib/src/readline/history.dart
@@ -1,0 +1,32 @@
+/// In-memory line history for editor navigation.
+final class LineHistory {
+  LineHistory({this.limit = 100, this.ignoreEmpty = true}) {
+    if (limit < 0) {
+      throw ArgumentError.value(limit, 'limit', 'must not be negative');
+    }
+  }
+
+  final int limit;
+  final bool ignoreEmpty;
+  final _entries = <String>[];
+
+  List<String> get entries => List<String>.unmodifiable(_entries);
+
+  int get length => _entries.length;
+
+  bool get isEmpty => _entries.isEmpty;
+
+  String operator [](int index) => _entries[index];
+
+  void add(String entry) {
+    if (ignoreEmpty && entry.isEmpty) return;
+    if (_entries.isNotEmpty && _entries.last == entry) return;
+
+    _entries.add(entry);
+    while (_entries.length > limit) {
+      _entries.removeAt(0);
+    }
+  }
+
+  void clear() => _entries.clear();
+}

--- a/lib/src/readline/line_buffer.dart
+++ b/lib/src/readline/line_buffer.dart
@@ -1,0 +1,99 @@
+import 'package:characters/characters.dart';
+
+/// Editable line state with a cursor measured in user-visible characters.
+final class LineBuffer {
+  LineBuffer([String text = '']) : _chars = text.characters.toList() {
+    _cursor = _chars.length;
+  }
+
+  final List<String> _chars;
+  var _cursor = 0;
+
+  String get text => _chars.join();
+
+  int get length => _chars.length;
+
+  bool get isEmpty => _chars.isEmpty;
+
+  int get cursor => _cursor;
+
+  set cursor(int value) {
+    _cursor = value.clamp(0, _chars.length);
+  }
+
+  void replace(String text, {int? cursor}) {
+    _chars
+      ..clear()
+      ..addAll(text.characters);
+    this.cursor = cursor ?? _chars.length;
+  }
+
+  bool insert(String text) {
+    if (text.isEmpty) return false;
+    final input = text.characters.toList();
+    if (input.isEmpty) return false;
+    _chars.insertAll(_cursor, input);
+    _cursor += input.length;
+    return true;
+  }
+
+  bool deleteBackward() {
+    if (_cursor == 0) return false;
+    _chars.removeAt(_cursor - 1);
+    _cursor--;
+    return true;
+  }
+
+  bool deleteForward() {
+    if (_cursor >= _chars.length) return false;
+    _chars.removeAt(_cursor);
+    return true;
+  }
+
+  bool clearBeforeCursor() {
+    if (_cursor == 0) return false;
+    _chars.removeRange(0, _cursor);
+    _cursor = 0;
+    return true;
+  }
+
+  bool clearAfterCursor() {
+    if (_cursor >= _chars.length) return false;
+    _chars.removeRange(_cursor, _chars.length);
+    return true;
+  }
+
+  bool moveLeft([int count = 1]) {
+    if (count <= 0) return false;
+    final previous = _cursor;
+    cursor = _cursor - count;
+    return _cursor != previous;
+  }
+
+  bool moveRight([int count = 1]) {
+    if (count <= 0) return false;
+    final previous = _cursor;
+    cursor = _cursor + count;
+    return _cursor != previous;
+  }
+
+  bool moveToStart() {
+    final previous = _cursor;
+    _cursor = 0;
+    return previous != _cursor;
+  }
+
+  bool moveToEnd() {
+    final previous = _cursor;
+    _cursor = _chars.length;
+    return previous != _cursor;
+  }
+
+  void clear() {
+    _chars.clear();
+    _cursor = 0;
+  }
+
+  @override
+  String toString() => 'LineBuffer(text: $text, cursor: $_cursor)';
+}

--- a/lib/src/tab/scripts/_utils.dart
+++ b/lib/src/tab/scripts/_utils.dart
@@ -1,3 +1,6 @@
 String nameForVar(String name) {
-  return name.replaceAll(r'-', r'_').replaceAll(r':', r'_');
+  final normalized = name.replaceAll(RegExp(r'[^A-Za-z0-9_]'), '_');
+  if (normalized.isEmpty) return '_';
+  if (RegExp(r'^[0-9]').hasMatch(normalized)) return '_$normalized';
+  return normalized;
 }

--- a/lib/src/tab/scripts/bash.dart
+++ b/lib/src/tab/scripts/bash.dart
@@ -11,7 +11,11 @@
 import '../flags.dart';
 import '_utils.dart';
 
-String bashScript(String name, String exec, {String backend = 'complete --'}) {
+String bashScript(
+  String name,
+  String exec, {
+  String completionCommand = 'complete --',
+}) {
   final escapedName = nameForVar(name);
   return '''# bash completion for $name
 #----------------------------------------
@@ -43,7 +47,7 @@ __${escapedName}_complete() {
     local requestComp out directive
 
     # Build the command to get completions
-    requestComp="$exec $backend \${words[@]:1}"
+    requestComp="$exec $completionCommand \${words[@]:1}"
 
     # Add an empty parameter if the last parameter is complete
     if [[ -z "\$cur" ]]; then

--- a/lib/src/tab/scripts/bash.dart
+++ b/lib/src/tab/scripts/bash.dart
@@ -11,7 +11,7 @@
 import '../flags.dart';
 import '_utils.dart';
 
-String bashScript(String name, String exec) {
+String bashScript(String name, String exec, {String backend = 'complete --'}) {
   final escapedName = nameForVar(name);
   return '''# bash completion for $name
 #----------------------------------------
@@ -43,7 +43,7 @@ __${escapedName}_complete() {
     local requestComp out directive
 
     # Build the command to get completions
-    requestComp="$exec complete -- \${words[@]:1}"
+    requestComp="$exec $backend \${words[@]:1}"
 
     # Add an empty parameter if the last parameter is complete
     if [[ -z "\$cur" ]]; then

--- a/lib/src/tab/scripts/fish.dart
+++ b/lib/src/tab/scripts/fish.dart
@@ -11,7 +11,11 @@
 import '../flags.dart';
 import '_utils.dart';
 
-String fishScript(String name, String exec, {String backend = 'complete --'}) {
+String fishScript(
+  String name,
+  String exec, {
+  String completionCommand = 'complete --',
+}) {
   final escapedName = nameForVar(name);
   return '''# fish completion for $name -*- shell-script -*-
 #----------------------------------------
@@ -46,7 +50,7 @@ function __${escapedName}_perform_completion
     __${escapedName}_debug "Last arg: \$last_arg"
 
     # Call the completion program and get the results
-    set -l requestComp "$exec $backend \$args[2..-1] \$last_arg"
+    set -l requestComp "$exec $completionCommand \$args[2..-1] \$last_arg"
     __${escapedName}_debug "Calling \$requestComp"
     set -l results (eval \$requestComp 2> /dev/null)
 

--- a/lib/src/tab/scripts/fish.dart
+++ b/lib/src/tab/scripts/fish.dart
@@ -11,7 +11,7 @@
 import '../flags.dart';
 import '_utils.dart';
 
-String fishScript(String name, String exec) {
+String fishScript(String name, String exec, {String backend = 'complete --'}) {
   final escapedName = nameForVar(name);
   return '''# fish completion for $name -*- shell-script -*-
 #----------------------------------------
@@ -46,7 +46,7 @@ function __${escapedName}_perform_completion
     __${escapedName}_debug "Last arg: \$last_arg"
 
     # Call the completion program and get the results
-    set -l requestComp "$exec complete -- \$args[2..-1] \$last_arg"
+    set -l requestComp "$exec $backend \$args[2..-1] \$last_arg"
     __${escapedName}_debug "Calling \$requestComp"
     set -l results (eval \$requestComp 2> /dev/null)
 

--- a/lib/src/tab/scripts/powershell.dart
+++ b/lib/src/tab/scripts/powershell.dart
@@ -21,13 +21,13 @@ String powershellScript(String name, String exec) {
 #-----------------------------------------------------
 
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-    function __${name}_debug {
+    function __${escapedName}_debug {
         if (\$env:BASH_COMP_DEBUG_FILE) {
             "\$args" | Out-File -Append -FilePath "\$env:BASH_COMP_DEBUG_FILE"
         }
     }
 
-    filter __${name}_escapeStringWithSpecialChars {
+    filter __${escapedName}_escapeStringWithSpecialChars {
         \$_ -replace '\\s|#|@|\\\$|;|,|''|\\{|\\}|\\(|\\)|"|\\||<|>|&','\\`\$&'
     }
 
@@ -42,9 +42,9 @@ String powershellScript(String name, String exec) {
     \$Command = \$CommandAst.CommandElements
     \$Command = "\$Command"
 
-    __${name}_debug ""
-    __${name}_debug "========= starting completion logic =========="
-    __${name}_debug "WordToComplete: \$WordToComplete Command: \$Command CursorPosition: \$CursorPosition"
+    __${escapedName}_debug ""
+    __${escapedName}_debug "========= starting completion logic =========="
+    __${escapedName}_debug "WordToComplete: \$WordToComplete Command: \$Command CursorPosition: \$CursorPosition"
 
     # The user could have moved the cursor backwards on the command-line.
     # We need to trigger completion from the \$CursorPosition location, so we need
@@ -54,7 +54,7 @@ String powershellScript(String name, String exec) {
     if (\$Command.Length -gt \$CursorPosition) {
         \$Command = \$Command.Substring(0, \$CursorPosition)
     }
-    __${name}_debug "Truncated command: \$Command"
+    __${escapedName}_debug "Truncated command: \$Command"
 
     \$ShellCompDirectiveError=${ShellCompDirective.error}
     \$ShellCompDirectiveNoSpace=${ShellCompDirective.noSpace}
@@ -68,7 +68,7 @@ String powershellScript(String name, String exec) {
     \$Program, \$Arguments = \$Command.Split(" ", 2)
 
     \$RequestComp = "& $exec complete -- \$Arguments"
-    __${name}_debug "RequestComp: \$RequestComp"
+    __${escapedName}_debug "RequestComp: \$RequestComp"
 
     # we cannot use \$WordToComplete because it
     # has the wrong values if the cursor was moved
@@ -76,13 +76,13 @@ String powershellScript(String name, String exec) {
     if (\$WordToComplete -ne "" ) {
         \$WordToComplete = \$Arguments.Split(" ")[-1]
     }
-    __${name}_debug "New WordToComplete: \$WordToComplete"
+    __${escapedName}_debug "New WordToComplete: \$WordToComplete"
 
 
     # Check for flag with equal sign
     \$IsEqualFlag = (\$WordToComplete -Like "--*=*" )
     if ( \$IsEqualFlag ) {
-        __${name}_debug "Completing equal sign flag"
+        __${escapedName}_debug "Completing equal sign flag"
         # Remove the flag part
         \$Flag, \$WordToComplete = \$WordToComplete.Split("=", 2)
     }
@@ -90,7 +90,7 @@ String powershellScript(String name, String exec) {
     if ( \$WordToComplete -eq "" -And ( -Not \$IsEqualFlag )) {
         # If the last parameter is complete (there is a space following it)
         # We add an extra empty parameter so we can indicate this to the go method.
-        __${name}_debug "Adding extra empty parameter"
+        __${escapedName}_debug "Adding extra empty parameter"
         # PowerShell 7.2+ changed the way how the arguments are passed to executables,
         # so for pre-7.2 or when Legacy argument passing is enabled we need to use
         if (\$PSVersionTable.PsVersion -lt [version]'7.2.0' -or
@@ -103,7 +103,7 @@ String powershellScript(String name, String exec) {
         }
     }
 
-    __${name}_debug "Calling \$RequestComp"
+    __${escapedName}_debug "Calling \$RequestComp"
     # First disable ActiveHelp which is not supported for Powershell
     \$env:ActiveHelp = 0
 
@@ -117,15 +117,15 @@ String powershellScript(String name, String exec) {
         # There is no directive specified
         \$Directive = 0
     }
-    __${name}_debug "The completion directive is: \$Directive"
+    __${escapedName}_debug "The completion directive is: \$Directive"
 
     # remove directive (last element) from out
     \$Out = \$Out | Where-Object { \$_ -ne \$Out[-1] }
-    __${name}_debug "The completions are: \$Out"
+    __${escapedName}_debug "The completions are: \$Out"
 
     if ((\$Directive -band \$ShellCompDirectiveError) -ne 0 ) {
         # Error code.  No completion.
-        __${name}_debug "Received error from custom completion code"
+        __${escapedName}_debug "Received error from custom completion code"
         return
     }
 
@@ -133,7 +133,7 @@ String powershellScript(String name, String exec) {
     [Array]\$Values = \$Out | ForEach-Object {
         # Split the output in name and description
         \$Name, \$Description = \$_.Split("`t", 2)
-        __${name}_debug "Name: \$Name Description: \$Description"
+        __${escapedName}_debug "Name: \$Name Description: \$Description"
 
         # Look for the longest completion so that we can format things nicely
         if (\$Longest -lt \$Name.Length) {
@@ -152,7 +152,7 @@ String powershellScript(String name, String exec) {
     \$Space = " "
     if ((\$Directive -band \$ShellCompDirectiveNoSpace) -ne 0 ) {
         # remove the space here
-        __${name}_debug "ShellCompDirectiveNoSpace is called"
+        __${escapedName}_debug "ShellCompDirectiveNoSpace is called"
         \$Space = ""
     }
 
@@ -160,7 +160,7 @@ String powershellScript(String name, String exec) {
         ((\$Directive -band \$ShellCompDirectiveFilterFileExt) -ne 0 ) -or
         ((\$Directive -band \$ShellCompDirectiveFilterDirs) -ne 0 )
     ) {
-        __${name}_debug "ShellCompDirectiveFilterFileExt ShellCompDirectiveFilterDirs are not supported"
+        __${escapedName}_debug "ShellCompDirectiveFilterFileExt ShellCompDirectiveFilterDirs are not supported"
 
         # return here to prevent the completion of the extensions
         return
@@ -172,7 +172,7 @@ String powershellScript(String name, String exec) {
 
         # Join the flag back if we have an equal sign flag
         if ( \$IsEqualFlag ) {
-            __${name}_debug "Join the equal sign flag back to the completion value"
+            __${escapedName}_debug "Join the equal sign flag back to the completion value"
             \$_.Name = \$Flag + "=" + \$_.Name
         }
     }
@@ -183,7 +183,7 @@ String powershellScript(String name, String exec) {
     }
 
     if ((\$Directive -band \$ShellCompDirectiveNoFileComp) -ne 0 ) {
-        __${name}_debug "ShellCompDirectiveNoFileComp is called"
+        __${escapedName}_debug "ShellCompDirectiveNoFileComp is called"
 
         if (\$Values.Length -eq 0) {
             # Just print an empty string here so the
@@ -197,7 +197,7 @@ String powershellScript(String name, String exec) {
 
     # Get the current mode
     \$Mode = (Get-PSReadLineKeyHandler | Where-Object { \$_.Key -eq "Tab" }).Function
-    __${name}_debug "Mode: \$Mode"
+    __${escapedName}_debug "Mode: \$Mode"
 
     \$Values | ForEach-Object {
 
@@ -222,10 +222,10 @@ String powershellScript(String name, String exec) {
             "Complete" {
 
                 if (\$Values.Length -eq 1) {
-                    __${name}_debug "Only one completion left"
+                    __${escapedName}_debug "Only one completion left"
 
                     # insert space after value
-                    \$CompletionText = \$(\$comp.Name | __${name}_escapeStringWithSpecialChars) + \$Space
+                    \$CompletionText = \$(\$comp.Name | __${escapedName}_escapeStringWithSpecialChars) + \$Space
                     if (\$ExecutionContext.SessionState.LanguageMode -eq "FullLanguage"){
                         [System.Management.Automation.CompletionResult]::new(\$CompletionText, "\$(\$comp.Name)", 'ParameterValue', "\$(\$comp.Description)")
                     } else {
@@ -259,7 +259,7 @@ String powershellScript(String name, String exec) {
                 # insert space after value
                 # MenuComplete will automatically show the ToolTip of
                 # the highlighted value at the bottom of the suggestions.
-                \$CompletionText = \$(\$comp.Name | __${name}_escapeStringWithSpecialChars) + \$Space
+                \$CompletionText = \$(\$comp.Name | __${escapedName}_escapeStringWithSpecialChars) + \$Space
                 if (\$ExecutionContext.SessionState.LanguageMode -eq "FullLanguage"){
                     [System.Management.Automation.CompletionResult]::new(\$CompletionText, "\$(\$comp.Name)", 'ParameterValue', "\$(\$comp.Description)")
                 } else {
@@ -272,7 +272,7 @@ String powershellScript(String name, String exec) {
                 # Like MenuComplete but we don't want to add a space here because
                 # the user need to press space anyway to get the completion.
                 # Description will not be shown because that's not possible with TabCompleteNext
-                \$CompletionText = \$(\$comp.Name | __${name}_escapeStringWithSpecialChars)
+                \$CompletionText = \$(\$comp.Name | __${escapedName}_escapeStringWithSpecialChars)
                 if (\$ExecutionContext.SessionState.LanguageMode -eq "FullLanguage"){
                     [System.Management.Automation.CompletionResult]::new(\$CompletionText, "\$(\$comp.Name)", 'ParameterValue', "\$(\$comp.Description)")
                 } else {

--- a/lib/src/tab/scripts/powershell.dart
+++ b/lib/src/tab/scripts/powershell.dart
@@ -11,7 +11,11 @@
 import '../flags.dart';
 import '_utils.dart';
 
-String powershellScript(String name, String exec) {
+String powershellScript(
+  String name,
+  String exec, {
+  String backend = 'complete --',
+}) {
   final escapedName = nameForVar(name);
   return '''# powershell completion for $name -*- shell-script -*-
 #-----------------------------------------------------
@@ -67,7 +71,7 @@ String powershellScript(String name, String exec) {
     # Split the command at the first space to separate the program and arguments.
     \$Program, \$Arguments = \$Command.Split(" ", 2)
 
-    \$RequestComp = "& $exec complete -- \$Arguments"
+    \$RequestComp = "& $exec $backend \$Arguments"
     __${escapedName}_debug "RequestComp: \$RequestComp"
 
     # we cannot use \$WordToComplete because it

--- a/lib/src/tab/scripts/powershell.dart
+++ b/lib/src/tab/scripts/powershell.dart
@@ -14,7 +14,7 @@ import '_utils.dart';
 String powershellScript(
   String name,
   String exec, {
-  String backend = 'complete --',
+  String completionCommand = 'complete --',
 }) {
   final escapedName = nameForVar(name);
   return '''# powershell completion for $name -*- shell-script -*-
@@ -71,7 +71,7 @@ String powershellScript(
     # Split the command at the first space to separate the program and arguments.
     \$Program, \$Arguments = \$Command.Split(" ", 2)
 
-    \$RequestComp = "& $exec $backend \$Arguments"
+    \$RequestComp = "& $exec $completionCommand \$Arguments"
     __${escapedName}_debug "RequestComp: \$RequestComp"
 
     # we cannot use \$WordToComplete because it

--- a/lib/src/tab/scripts/zsh.dart
+++ b/lib/src/tab/scripts/zsh.dart
@@ -11,7 +11,7 @@
 import '../flags.dart';
 import '_utils.dart';
 
-String zshScript(String name, String exec) {
+String zshScript(String name, String exec, {String backend = 'complete --'}) {
   final escapedName = nameForVar(name);
   return '''#compdef $name
 compdef _$escapedName $name
@@ -77,7 +77,7 @@ _$escapedName() {
     local quoted_args=("\${(@q)args_to_quote}")
 
     # Join the main command and the quoted arguments into a single string for eval
-    requestComp="$exec complete -- \${quoted_args[*]}"
+    requestComp="$exec $backend \${quoted_args[*]}"
 
     __${escapedName}_debug "About to call: eval \${requestComp}"
 

--- a/lib/src/tab/scripts/zsh.dart
+++ b/lib/src/tab/scripts/zsh.dart
@@ -11,7 +11,11 @@
 import '../flags.dart';
 import '_utils.dart';
 
-String zshScript(String name, String exec, {String backend = 'complete --'}) {
+String zshScript(
+  String name,
+  String exec, {
+  String completionCommand = 'complete --',
+}) {
   final escapedName = nameForVar(name);
   return '''#compdef $name
 compdef _$escapedName $name
@@ -77,7 +81,7 @@ _$escapedName() {
     local quoted_args=("\${(@q)args_to_quote}")
 
     # Join the main command and the quoted arguments into a single string for eval
-    requestComp="$exec $backend \${quoted_args[*]}"
+    requestComp="$exec $completionCommand \${quoted_args[*]}"
 
     __${escapedName}_debug "About to call: eval \${requestComp}"
 

--- a/lib/src/tab/shell.dart
+++ b/lib/src/tab/shell.dart
@@ -10,5 +10,12 @@ enum Shell {
   zsh(zshScript);
 
   const Shell(this.generate);
-  final String Function(String name, String exec, {String backend}) generate;
+
+  /// Generates a completion script for [name].
+  ///
+  /// [exec] is the command used to invoke the completion provider.
+  /// [completionCommand] is appended after [exec] before the active shell words.
+  /// The default matches Coal's completion protocol: `$exec complete -- ...`.
+  final String Function(String name, String exec, {String completionCommand})
+  generate;
 }

--- a/lib/src/tab/shell.dart
+++ b/lib/src/tab/shell.dart
@@ -10,5 +10,5 @@ enum Shell {
   zsh(zshScript);
 
   const Shell(this.generate);
-  final String Function(String name, String exec) generate;
+  final String Function(String name, String exec, {String backend}) generate;
 }

--- a/lib/src/tab/tab.dart
+++ b/lib/src/tab/tab.dart
@@ -36,25 +36,6 @@ class Tab extends Command {
     if (shouldCompleteFlags(lastPreArg, toComplete)) {
       handleFlagCompletion(matchedCommand, toComplete, lastPreArg);
     } else {
-      if (lastPreArg?.startsWith('-') == true &&
-          toComplete.isEmpty &&
-          endsWithSpace) {
-        Option? option = lastPreArg != null
-            ? findOption(this, lastPreArg)
-            : null;
-        if (option != null && lastPreArg != null) {
-          for (final command in commands.values) {
-            option = findOption(command, lastPreArg);
-            if (option != null) break;
-          }
-        }
-
-        if (option != null && option.isBool == true) {
-          complete(toComplete);
-          return;
-        }
-      }
-
       if (shouldCompleteCommands(toComplete)) {
         handleCommandCompletion(previousArgs, toComplete);
       }
@@ -93,23 +74,23 @@ extension on Tab {
     return null;
   }
 
+  Option? findAnyOption(String name) {
+    if (findOption(this, name) case final Option option) return option;
+
+    for (final command in commands.values) {
+      if (findOption(command, name) case final Option option) return option;
+    }
+
+    return null;
+  }
+
   List<String> stripOptions(Iterable<String> args) {
     final result = <String>[], length = args.length;
     for (int index = 0; index < length;) {
       final arg = args.elementAt(index);
       if (arg.startsWith('-')) {
         index++;
-        bool isBool = false;
-        if (findOption(this, arg) case final Option option) {
-          isBool = option.isBool ?? false;
-        } else {
-          for (final MapEntry(value: command) in commands.entries) {
-            if (findOption(command, arg) case final Option option) {
-              isBool = option.isBool ?? false;
-              break;
-            }
-          }
-        }
+        final isBool = findAnyOption(arg)?.isBool ?? false;
 
         if (!isBool &&
             index < length &&
@@ -148,13 +129,7 @@ extension on Tab {
   bool shouldCompleteFlags(String? lastPrevArg, String toComplete) {
     if (toComplete.startsWith('-')) return true;
     if (lastPrevArg != null && lastPrevArg.startsWith('-') == true) {
-      Option? option = findOption(this, lastPrevArg);
-      if (option == null) {
-        for (final command in commands.values) {
-          option = findOption(command, lastPrevArg);
-          if (option != null) break;
-        }
-      }
+      final option = findAnyOption(lastPrevArg);
 
       if (option != null && option.isBool == true) {
         return false;
@@ -183,16 +158,9 @@ extension on Tab {
     if (optionName != null && optionName.isNotEmpty) {
       final option = findOption(command, optionName);
       if (option?.handler != null) {
-        final suggestions = <Completion>[];
-        option?.handler?.call(
-          (value, description) => suggestions.add(
-            Completion(value: value, description: description),
-          ),
-          command.options,
-        );
         completions
           ..clear()
-          ..addAll(suggestions);
+          ..addAll(collectCompletions(option!.handler!, command.options));
       }
       return;
     }
@@ -271,14 +239,23 @@ extension on Tab {
     }
 
     if (targetArgument != null && targetArgument.handler != null) {
-      final suggestions = <Completion>[];
-      targetArgument.handler?.call(
-        (value, description) =>
-            suggestions.add(Completion(value: value, description: description)),
-        command.options,
+      completions.addAll(
+        collectCompletions(targetArgument.handler!, command.options),
       );
-      completions.addAll(suggestions);
     }
+  }
+
+  List<Completion> collectCompletions(
+    CompleteHandler handler,
+    Map<String, Option> options,
+  ) {
+    final suggestions = <Completion>[];
+    handler(
+      (value, description) =>
+          suggestions.add(Completion(value: value, description: description)),
+      options,
+    );
+    return suggestions;
   }
 
   void complete(String toComplete) {

--- a/lib/src/utils/scroll.dart
+++ b/lib/src/utils/scroll.dart
@@ -13,9 +13,9 @@ String scrollDown([int count = 1]) => '${csi}T' * count;
 @pragma('vm:prefer-inline')
 @pragma('wasm:prefer-inline')
 @pragma('dart2js:prefer-inline')
-String scrollLeft([int count = 1]) => '${csi}Z' * count;
+String scrollLeft([int count = 1]) => '$csi @' * count;
 
 @pragma('vm:prefer-inline')
 @pragma('wasm:prefer-inline')
 @pragma('dart2js:prefer-inline')
-String scrollRight([int count = 1]) => '${csi}A' * count;
+String scrollRight([int count = 1]) => '$csi A' * count;

--- a/lib/tab/args.dart
+++ b/lib/tab/args.dart
@@ -47,9 +47,6 @@ extension on CompleteCommand {
   (String, String) resolveExecInfo() {
     final script = Platform.script.toFilePath();
     final exec = Platform.resolvedExecutable;
-    // if (script.endsWith('.dart') && exec.endsWith('/dart')) {
-    //   throw UnsupportedError('dart run <file> is not currently supported');
-    // }
 
     final name = script.split(Platform.pathSeparator).last;
     if (script == exec) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,14 +121,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
-  ht:
-    dependency: transitive
-    description:
-      name: ht
-      sha256: f0d7413cb63e471d989e551b8eb05496fdec5a1c7596e5177669b1cf717882f1
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -209,22 +201,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
-  ocookie:
-    dependency: transitive
-    description:
-      name: ocookie
-      sha256: b3dd5f8abe623e13a4ca88f0de90dd3309fca3b70652eff1a3a11a648ee20edb
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0"
-  oxy:
-    dependency: "direct dev"
-    description:
-      name: oxy
-      sha256: "577b4972e0e1095e2b3925c7017e3e2df79a6143c7ae463d5b855de63774c8af"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0"
   package_config:
     dependency: transitive
     description:
@@ -442,4 +418,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
+  dart: ">=3.9.2 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: coal
-description: A suite for easily building beautiful command-line apps.
-version: 0.0.6
+description: A focused utility suite for building polished Dart command-line apps.
+version: 0.0.7
 repository: https://github.com/medz/coal
 
 environment:
@@ -16,5 +16,4 @@ dependencies:
 dev_dependencies:
   benchmark_harness: ^2.3.1
   lints: ^6.0.0
-  oxy: ^0.1.0
   test: ^1.25.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,9 @@ repository: https://github.com/medz/coal
 environment:
   sdk: ^3.9.2
 
+executables:
+  coal:
+
 dependencies:
   # Required by lib/tab/args.dart for CommandRunner integration.
   args: ^2.7.0

--- a/test/args_test.dart
+++ b/test/args_test.dart
@@ -160,6 +160,15 @@ void main() {
       final args = Args.parse(input);
       expect(args.toJson(), output);
     });
+
+    test("preserves sibling values", () {
+      const input = ["--db.host", "localhost", "--db.port", "5432"];
+      const output = {
+        "db": {"host": "localhost", "port": 5432},
+      };
+      final args = Args.parse(input);
+      expect(args.toJson(), output);
+    });
   });
 
   group("negated", () {
@@ -250,6 +259,15 @@ void main() {
       final args = Args.parse(input, aliases: {'a': "add"}, bool: ['add']);
 
       expect(args.toJson(), output);
+    });
+  });
+
+  group("defaults", () {
+    test("keeps typed access stable when input is empty", () {
+      final args = Args.parse(const [], defaults: const {"port": 3000});
+
+      expect(args.toJson(), {"port": 3000});
+      expect(args["port"]?.as<int>(), 3000);
     });
   });
 }

--- a/test/cli_test.dart
+++ b/test/cli_test.dart
@@ -1,0 +1,63 @@
+import 'package:coal/src/cli/cli.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('coal cli', () {
+    test('reports shell support', () async {
+      final output = StringBuffer();
+      final code = await runCoal(
+        <String>['doctor'],
+        out: output,
+        hasCommand: (command) => command == 'bash',
+      );
+
+      expect(code, 0);
+      expect(output.toString(), contains('bash: ok'));
+      expect(output.toString(), contains('zsh: missing'));
+    });
+
+    test('generates coal completion script', () async {
+      final output = StringBuffer();
+      final code = await runCoal(<String>['complete', 'bash'], out: output);
+
+      expect(code, 0);
+      expect(output.toString(), contains('complete -F __coal_complete coal'));
+    });
+
+    test('generates dart completion script', () async {
+      final output = StringBuffer();
+      final code = await runCoal(<String>[
+        'dart-complete',
+        'bash',
+      ], out: output);
+
+      expect(code, 0);
+      expect(output.toString(), contains('complete -F __dart_complete dart'));
+      expect(output.toString(), contains('coal dart-complete --'));
+    });
+
+    test('completes dart commands', () async {
+      final output = StringBuffer();
+      final code = await runCoal(<String>[
+        'dart-complete',
+        '--',
+        'pu',
+      ], out: output);
+
+      expect(code, 0);
+      expect(output.toString(), contains('pub\tWork with packages'));
+    });
+
+    test('returns usage error for unsupported dart completion shell', () async {
+      final errors = StringBuffer();
+      final code = await runCoal(
+        <String>['dart-complete', 'unknown'],
+        out: StringBuffer(),
+        err: errors,
+      );
+
+      expect(code, 64);
+      expect(errors.toString(), contains('Unsupported shell'));
+    });
+  });
+}

--- a/test/keypass_test.dart
+++ b/test/keypass_test.dart
@@ -11,6 +11,8 @@ void main() {
       expect(normalizeKeyBinding('spacebar'), 'space');
       expect(normalizeKeyBinding('ArrowUp'), 'up');
       expect(normalizeKeyBinding('cmd + pgdown'), 'meta+pagedown');
+      expect(normalizeKeyBinding('+'), 'plus');
+      expect(normalizeKeyBinding('ctrl++'), 'ctrl+plus');
     });
 
     test('throws for invalid bindings', () {
@@ -45,6 +47,10 @@ void main() {
       expect(KeyDecoder.decodeSequence('\u001b[3~'), KeyEvent('delete'));
       expect(KeyDecoder.decodeSequence('\u001bOP'), KeyEvent('f1'));
       expect(KeyDecoder.decodeSequence('\u001ba'), KeyEvent('a', meta: true));
+      expect(
+        KeyDecoder.decodeSequence('\u001b[200~'),
+        const ControlSequenceInput('\u001b[200~'),
+      );
     });
   });
 
@@ -82,6 +88,28 @@ void main() {
       expect(parser.addString('\u001b'), isEmpty);
       expect(parser.flush(), <KeyInput>[KeyEvent('escape')]);
     });
+
+    test('keeps unsupported control sequences out of text input', () {
+      final parser = KeyParser();
+
+      expect(parser.addString('\u001b[200~abc'), <KeyInput>[
+        const ControlSequenceInput('\u001b[200~'),
+        const TextInput('abc'),
+      ]);
+      expect(parser.addString('\u001b[?25h'), <KeyInput>[
+        const ControlSequenceInput('\u001b[?25h'),
+      ]);
+      expect(parser.addString('\u001b[I'), <KeyInput>[
+        const ControlSequenceInput('\u001b[I'),
+      ]);
+    });
+
+    test('flushes incomplete control sequences as control input', () {
+      final parser = KeyParser();
+
+      expect(parser.addString('\u001b['), isEmpty);
+      expect(parser.flush(), <KeyInput>[const ControlSequenceInput('\u001b[')]);
+    });
   });
 
   group('key dispatcher', () {
@@ -89,12 +117,15 @@ void main() {
       final triggered = <String>[];
       final dispatcher = KeyDispatcher()
         ..bind('ctrl+c', (event) => triggered.add(event.binding))
+        ..bind('ctrl+c', (event) => triggered.add('again:${event.binding}'))
         ..bind('shift+up', (event) => triggered.add(event.binding));
 
+      expect(dispatcher.bindingCount, 2);
+      expect(dispatcher.handlerCount, 3);
       expect(dispatcher.dispatch(KeyEvent('c', ctrl: true)), isTrue);
       expect(dispatcher.dispatch(KeyEvent('up', shift: true)), isTrue);
       expect(dispatcher.dispatch(KeyEvent('down')), isFalse);
-      expect(triggered, <String>['ctrl+c', 'shift+up']);
+      expect(triggered, <String>['ctrl+c', 'again:ctrl+c', 'shift+up']);
     });
 
     test('replaces and removes handlers', () {

--- a/test/keypass_test.dart
+++ b/test/keypass_test.dart
@@ -1,0 +1,140 @@
+import 'dart:convert';
+
+import 'package:coal/keypass.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('key binding normalization', () {
+    test('normalizes modifiers and aliases', () {
+      expect(normalizeKeyBinding('Shift + Ctrl + A'), 'ctrl+shift+a');
+      expect(normalizeKeyBinding('alt + Enter'), 'meta+enter');
+      expect(normalizeKeyBinding('spacebar'), 'space');
+      expect(normalizeKeyBinding('ArrowUp'), 'up');
+      expect(normalizeKeyBinding('cmd + pgdown'), 'meta+pagedown');
+    });
+
+    test('throws for invalid bindings', () {
+      expect(() => normalizeKeyBinding(''), throwsFormatException);
+      expect(() => normalizeKeyBinding('ctrl+meta'), throwsFormatException);
+      expect(
+        () => normalizeKeyBinding('ctrl+a+b'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('key sequence decoder', () {
+    test('decodes text separately from control keys', () {
+      expect(KeyDecoder.decodeSequence('coal'), const TextInput('coal'));
+      expect(KeyDecoder.decodeSequence('\u0003'), KeyEvent('c', ctrl: true));
+      expect(KeyDecoder.decodeSequence('\t'), KeyEvent('tab'));
+      expect(KeyDecoder.decodeSequence('\r'), KeyEvent('enter'));
+      expect(KeyDecoder.decodeSequence('\u007f'), KeyEvent('backspace'));
+    });
+
+    test('decodes ansi keys and modifiers', () {
+      expect(KeyDecoder.decodeSequence('\u001b[A'), KeyEvent('up'));
+      expect(
+        KeyDecoder.decodeSequence('\u001b[1;6A'),
+        KeyEvent('up', ctrl: true, shift: true),
+      );
+      expect(
+        KeyDecoder.decodeSequence('\u001b[Z'),
+        KeyEvent('tab', shift: true),
+      );
+      expect(KeyDecoder.decodeSequence('\u001b[3~'), KeyEvent('delete'));
+      expect(KeyDecoder.decodeSequence('\u001bOP'), KeyEvent('f1'));
+      expect(KeyDecoder.decodeSequence('\u001ba'), KeyEvent('a', meta: true));
+    });
+  });
+
+  group('key parser', () {
+    test('buffers partial escape sequences', () {
+      final parser = KeyParser();
+
+      expect(parser.addString('\u001b['), isEmpty);
+      expect(parser.addString('A'), <KeyInput>[KeyEvent('up')]);
+    });
+
+    test('splits compound escape and text chunks', () {
+      final parser = KeyParser();
+
+      expect(parser.addString('\u001b[Aa'), <KeyInput>[
+        KeyEvent('up'),
+        const TextInput('a'),
+      ]);
+    });
+
+    test('streams split utf8 text bytes', () {
+      final parser = KeyParser();
+      final bytes = utf8.encode('你a');
+
+      expect(parser.addBytes(bytes.sublist(0, 1)), isEmpty);
+      expect(parser.addBytes(bytes.sublist(1, 2)), isEmpty);
+      expect(parser.addBytes(bytes.sublist(2)), <KeyInput>[
+        const TextInput('你a'),
+      ]);
+    });
+
+    test('flushes a pending escape key', () {
+      final parser = KeyParser();
+
+      expect(parser.addString('\u001b'), isEmpty);
+      expect(parser.flush(), <KeyInput>[KeyEvent('escape')]);
+    });
+  });
+
+  group('key dispatcher', () {
+    test('binds and dispatches handlers', () {
+      final triggered = <String>[];
+      final dispatcher = KeyDispatcher()
+        ..bind('ctrl+c', (event) => triggered.add(event.binding))
+        ..bind('shift+up', (event) => triggered.add(event.binding));
+
+      expect(dispatcher.dispatch(KeyEvent('c', ctrl: true)), isTrue);
+      expect(dispatcher.dispatch(KeyEvent('up', shift: true)), isTrue);
+      expect(dispatcher.dispatch(KeyEvent('down')), isFalse);
+      expect(triggered, <String>['ctrl+c', 'shift+up']);
+    });
+
+    test('replaces and removes handlers', () {
+      final values = <int>[];
+      final dispatcher = KeyDispatcher();
+
+      void first(KeyEvent _) => values.add(1);
+      void second(KeyEvent _) => values.add(2);
+
+      dispatcher
+        ..bind('tab', first)
+        ..bind('tab', second)
+        ..dispatch(KeyEvent('tab'));
+      expect(values, <int>[1, 2]);
+
+      dispatcher
+        ..bind('tab', second, replace: true)
+        ..dispatch(KeyEvent('tab'));
+      expect(values, <int>[1, 2, 2]);
+
+      expect(dispatcher.unbind('tab', second), isTrue);
+      expect(dispatcher.isBound('tab'), isFalse);
+    });
+  });
+
+  group('keypass facade', () {
+    test('dispatches parsed key events and returns all inputs', () {
+      final triggered = <String>[];
+      final keypass = Keypass()
+        ..bind('ctrl+c', (event) => triggered.add(event.binding))
+        ..bind('up', (event) => triggered.add(event.binding));
+
+      final inputs = keypass.addString('\u0003\u001b[Aok');
+
+      expect(inputs, <KeyInput>[
+        KeyEvent('c', ctrl: true),
+        KeyEvent('up'),
+        const TextInput('ok'),
+      ]);
+      expect(triggered, <String>['ctrl+c', 'up']);
+    });
+  });
+}

--- a/test/keypass_test.dart
+++ b/test/keypass_test.dart
@@ -149,6 +149,18 @@ void main() {
       expect(dispatcher.unbind('tab', second), isTrue);
       expect(dispatcher.isBound('tab'), isFalse);
     });
+
+    test('rejects printable-only bindings', () {
+      final dispatcher = KeyDispatcher();
+
+      expect(() => dispatcher.bind('a', (_) {}), throwsA(isA<ArgumentError>()));
+      expect(
+        () => dispatcher.bind('shift+a', (_) {}),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(() => dispatcher.bind('ctrl+a', (_) {}), returnsNormally);
+      expect(() => dispatcher.bind('meta+a', (_) {}), returnsNormally);
+    });
   });
 
   group('keypass facade', () {

--- a/test/readline_test.dart
+++ b/test/readline_test.dart
@@ -1,0 +1,133 @@
+import 'package:coal/keypass.dart';
+import 'package:coal/readline.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('line buffer', () {
+    test('edits text around the cursor', () {
+      final buffer = LineBuffer('coal');
+
+      expect(buffer.moveLeft(), isTrue);
+      expect(buffer.insert('!'), isTrue);
+      expect(buffer.text, 'coa!l');
+      expect(buffer.cursor, 4);
+
+      expect(buffer.deleteBackward(), isTrue);
+      expect(buffer.deleteForward(), isTrue);
+      expect(buffer.text, 'coa');
+      expect(buffer.moveToStart(), isTrue);
+      expect(buffer.insert('hot '), isTrue);
+      expect(buffer.text, 'hot coa');
+    });
+
+    test('measures cursor by grapheme clusters', () {
+      final buffer = LineBuffer('a👩‍💻b');
+
+      expect(buffer.length, 3);
+      expect(buffer.moveLeft(2), isTrue);
+      expect(buffer.insert('x'), isTrue);
+      expect(buffer.text, 'ax👩‍💻b');
+      expect(buffer.cursor, 2);
+      expect(buffer.moveLeft(0), isFalse);
+      expect(buffer.moveRight(-1), isFalse);
+    });
+  });
+
+  group('line history', () {
+    test('limits entries and skips empty and adjacent duplicates', () {
+      final history = LineHistory(limit: 2);
+
+      history
+        ..add('')
+        ..add('one')
+        ..add('one')
+        ..add('two')
+        ..add('three');
+
+      expect(history.entries, <String>['two', 'three']);
+    });
+
+    test('rejects negative limits', () {
+      expect(() => LineHistory(limit: -1), throwsArgumentError);
+    });
+  });
+
+  group('line editor', () {
+    test('inserts text and applies cursor editing keys', () {
+      final editor = LineEditor();
+
+      expect(
+        editor.apply(const TextInput('coal')).action,
+        LineEditAction.changed,
+      );
+      expect(editor.apply(KeyEvent('left')).action, LineEditAction.changed);
+      expect(editor.apply(const TextInput('!')).value, 'coa!l');
+      expect(editor.apply(KeyEvent('backspace')).value, 'coal');
+      expect(editor.apply(KeyEvent('home')).action, LineEditAction.changed);
+      expect(editor.apply(const TextInput('hot ')).value, 'hot coal');
+      expect(editor.apply(KeyEvent('end')).action, LineEditAction.changed);
+      expect(editor.text, 'hot coal');
+    });
+
+    test('supports delete and line clearing shortcuts', () {
+      final editor = LineEditor()..apply(const TextInput('abcdef'));
+
+      editor
+        ..apply(KeyEvent('left'))
+        ..apply(KeyEvent('left'));
+      expect(editor.apply(KeyEvent('delete')).value, 'abcdf');
+      expect(editor.apply(KeyEvent('u', ctrl: true)).value, 'f');
+      expect(editor.apply(KeyEvent('k', ctrl: true)).value, '');
+    });
+
+    test('submits, cancels, and reports eof', () {
+      final editor = LineEditor();
+
+      editor.apply(const TextInput('coal'));
+      final submitted = editor.apply(KeyEvent('enter'));
+      expect(submitted.action, LineEditAction.submitted);
+      expect(submitted.value, 'coal');
+      expect(submitted.isTerminal, isTrue);
+      expect(editor.text, isEmpty);
+      expect(editor.history.entries, <String>['coal']);
+
+      editor.apply(const TextInput('draft'));
+      final canceled = editor.apply(KeyEvent('c', ctrl: true));
+      expect(canceled.action, LineEditAction.canceled);
+      expect(canceled.value, 'draft');
+      expect(
+        editor.apply(KeyEvent('d', ctrl: true)).action,
+        LineEditAction.eof,
+      );
+    });
+
+    test('navigates history and restores the draft', () {
+      final editor = LineEditor();
+
+      editor
+        ..apply(const TextInput('one'))
+        ..apply(KeyEvent('enter'))
+        ..apply(const TextInput('two'))
+        ..apply(KeyEvent('enter'))
+        ..apply(const TextInput('dra'));
+
+      expect(editor.apply(KeyEvent('up')).value, 'two');
+      expect(editor.apply(KeyEvent('up')).value, 'one');
+      expect(editor.apply(KeyEvent('up')).action, LineEditAction.none);
+      expect(editor.apply(KeyEvent('down')).value, 'two');
+      expect(editor.apply(KeyEvent('down')).value, 'dra');
+    });
+
+    test('works with KeyParser output', () {
+      final editor = LineEditor();
+      final parser = KeyParser();
+
+      for (final input in parser.addString('co\u001b[D!')) {
+        editor.apply(input);
+      }
+
+      expect(editor.text, 'c!o');
+      expect(editor.cursor, 2);
+    });
+  });
+}

--- a/test/readline_test.dart
+++ b/test/readline_test.dart
@@ -129,5 +129,16 @@ void main() {
       expect(editor.text, 'c!o');
       expect(editor.cursor, 2);
     });
+
+    test('ignores unsupported control sequences', () {
+      final editor = LineEditor();
+      final parser = KeyParser();
+
+      for (final input in parser.addString('a\u001b[200~b')) {
+        editor.apply(input);
+      }
+
+      expect(editor.text, 'ab');
+    });
   });
 }

--- a/test/tab/behavior_contract_cases.dart
+++ b/test/tab/behavior_contract_cases.dart
@@ -102,6 +102,17 @@ final List<ParseContractCase> parseContractCases = <ParseContractCase>[
     ),
   ),
   ParseContractCase(
+    key: 'boolean-option-empty-token',
+    description: 'completes root commands after bool option and trailing space',
+    input: <String>['--verbose', ''],
+    expectations: ParseContractExpectations(
+      exactCompletions: <String>[
+        'project\tProject operations',
+        'deploy\tDeploy service',
+      ],
+    ),
+  ),
+  ParseContractCase(
     key: 'root-subcommand-completion',
     description: 'completes root command names',
     input: <String>['pro'],

--- a/test/tab/example_smoke_test.dart
+++ b/test/tab/example_smoke_test.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+bool hasCommand(String command) {
+  try {
+    final lookup = Platform.isWindows ? 'where' : 'which';
+    final result = Process.runSync(lookup, [command]);
+    return result.exitCode == 0;
+  } catch (_) {
+    return false;
+  }
+}
+
+void main() {
+  group('tab examples', () {
+    test(
+      'source tab example generates valid bash completion',
+      () async {
+        final result = await Process.run(Platform.resolvedExecutable, [
+          'run',
+          'example/tab.dart',
+          'complete',
+          'bash',
+        ]);
+
+        expect(
+          result.exitCode,
+          0,
+          reason: '${result.stdout}\n${result.stderr}',
+        );
+
+        final tmp = await Directory.systemTemp.createTemp(
+          'coal-tab-example-smoke-',
+        );
+        addTearDown(() => tmp.delete(recursive: true));
+        final script = File('${tmp.path}/tab.bash');
+        await script.writeAsString(result.stdout as String);
+
+        final check = await Process.run('bash', ['-n', script.path]);
+
+        expect(check.exitCode, 0, reason: check.stderr);
+      },
+      skip: !hasCommand('bash'),
+    );
+  });
+}

--- a/test/tab/golden_test.dart
+++ b/test/tab/golden_test.dart
@@ -39,7 +39,10 @@ Future<void> expectGolden(String relativePath, String actual) async {
     await file.writeAsString(normalizedActual);
   }
 
-  final normalizedExpected = (await file.readAsString()).replaceAll('\r\n', '\n');
+  final normalizedExpected = (await file.readAsString()).replaceAll(
+    '\r\n',
+    '\n',
+  );
   expect(
     normalizedActual,
     normalizedExpected,

--- a/test/tab/script_backend_test.dart
+++ b/test/tab/script_backend_test.dart
@@ -2,20 +2,36 @@ import 'package:coal/tab.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('shell completion backend', () {
-    test('uses the default complete backend', () {
+  group('shell completion command', () {
+    test('uses the default complete command', () {
       expect(
         Shell.bash.generate('coal', 'coal'),
         contains('requestComp="coal complete --'),
       );
     });
 
-    test('supports a custom backend command', () {
+    test('supports a custom completion command', () {
       final scripts = <String>[
-        Shell.bash.generate('dart', 'coal dart-complete', backend: '--'),
-        Shell.zsh.generate('dart', 'coal dart-complete', backend: '--'),
-        Shell.fish.generate('dart', 'coal dart-complete', backend: '--'),
-        Shell.powershell.generate('dart', 'coal dart-complete', backend: '--'),
+        Shell.bash.generate(
+          'dart',
+          'coal dart-complete',
+          completionCommand: '--',
+        ),
+        Shell.zsh.generate(
+          'dart',
+          'coal dart-complete',
+          completionCommand: '--',
+        ),
+        Shell.fish.generate(
+          'dart',
+          'coal dart-complete',
+          completionCommand: '--',
+        ),
+        Shell.powershell.generate(
+          'dart',
+          'coal dart-complete',
+          completionCommand: '--',
+        ),
       ];
 
       for (final script in scripts) {

--- a/test/tab/script_backend_test.dart
+++ b/test/tab/script_backend_test.dart
@@ -1,0 +1,27 @@
+import 'package:coal/tab.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('shell completion backend', () {
+    test('uses the default complete backend', () {
+      expect(
+        Shell.bash.generate('coal', 'coal'),
+        contains('requestComp="coal complete --'),
+      );
+    });
+
+    test('supports a custom backend command', () {
+      final scripts = <String>[
+        Shell.bash.generate('dart', 'coal dart-complete', backend: '--'),
+        Shell.zsh.generate('dart', 'coal dart-complete', backend: '--'),
+        Shell.fish.generate('dart', 'coal dart-complete', backend: '--'),
+        Shell.powershell.generate('dart', 'coal dart-complete', backend: '--'),
+      ];
+
+      for (final script in scripts) {
+        expect(script, contains('coal dart-complete --'));
+        expect(script, isNot(contains('coal dart-complete complete --')));
+      }
+    });
+  });
+}

--- a/test/tab/script_contract_cases.dart
+++ b/test/tab/script_contract_cases.dart
@@ -119,6 +119,14 @@ final List<ScriptContractCase> scriptContractCases = <ScriptContractCase>[
           'complete -c $specialName -f -a "(eval __${escapedName}_perform_completion)"',
         ],
       ),
+      ContractShell.powershell: ShellScriptExpectations(
+        contains: <String>[
+          'function __${escapedName}_debug',
+          'filter __${escapedName}_escapeStringWithSpecialChars',
+          '[scriptblock]\$__${escapedName}CompleterBlock',
+          "Register-ArgumentCompleter -CommandName '$specialName'",
+        ],
+      ),
     },
   ),
 ];

--- a/test/tab/script_runtime_test.dart
+++ b/test/tab/script_runtime_test.dart
@@ -89,7 +89,7 @@ void main() {
       );
       addTearDown(() => tmp.delete(recursive: true));
 
-      final backend = await writeScript(
+      final completion = await writeScript(
         '${tmp.path}/mock_complete.sh',
         '''#!/usr/bin/env bash
 if [[ "\$1" == "complete" && "\$2" == "--" ]]; then
@@ -103,7 +103,7 @@ exit 1
 
       final script = await writeScript(
         '${tmp.path}/coaltest.bash',
-        Shell.bash.generate('coaltest', backend.path),
+        Shell.bash.generate('coaltest', completion.path),
       );
 
       final harness = r'''
@@ -149,6 +149,78 @@ printf '%s\n' "${COMPREPLY[@]}"
           .where((line) => line.isNotEmpty)
           .toList();
       expect(output, contains('--name'));
+    }, skip: !runBash);
+
+    test('bash script executes custom completion command flow', () async {
+      final tmp = await Directory.systemTemp.createTemp(
+        'coal-tab-bash-custom-runtime-',
+      );
+      addTearDown(() => tmp.delete(recursive: true));
+
+      final completion = await writeScript(
+        '${tmp.path}/mock_custom_complete.sh',
+        '''#!/usr/bin/env bash
+if [[ "\$1" == "--" ]]; then
+  printf '%s\n' 'pub\tWork with packages' ':0'
+  exit 0
+fi
+exit 1
+''',
+        executable: true,
+      );
+
+      final script = await writeScript(
+        '${tmp.path}/coaltest.bash',
+        Shell.bash.generate(
+          'coaltest',
+          completion.path,
+          completionCommand: '--',
+        ),
+      );
+
+      final harness = r'''
+set -euo pipefail
+
+_get_comp_words_by_ref() {
+  local OPTIND opt
+  while getopts "n:" opt; do :; done
+  shift $((OPTIND - 1))
+
+  local curvar="$1" prevvar="$2" wordsvar="$3" cwordvar="$4"
+  printf -v "$curvar" '%s' "${COMP_WORDS[COMP_CWORD]}"
+  if (( COMP_CWORD > 0 )); then
+    printf -v "$prevvar" '%s' "${COMP_WORDS[COMP_CWORD-1]}"
+  else
+    printf -v "$prevvar" ''
+  fi
+  eval "$wordsvar=(\"${COMP_WORDS[@]}\")"
+  printf -v "$cwordvar" '%s' "$COMP_CWORD"
+}
+
+source "$COMPLETION_FILE"
+COMP_WORDS=(coaltest pu)
+COMP_CWORD=1
+__coaltest_complete
+printf '%s\n' "${COMPREPLY[@]}"
+''';
+
+      final result = await Process.run(
+        'bash',
+        ['-lc', harness],
+        environment: {'COMPLETION_FILE': script.path},
+      );
+
+      expect(
+        result.exitCode,
+        0,
+        reason: 'bash custom runtime failed: ${result.stderr}',
+      );
+      final output = (result.stdout as String)
+          .split('\n')
+          .map((line) => line.trim())
+          .where((line) => line.isNotEmpty)
+          .toList();
+      expect(output, contains('pub'));
     }, skip: !runBash);
 
     test('zsh script passes syntax check', () async {

--- a/test/utils/scroll_test.dart
+++ b/test/utils/scroll_test.dart
@@ -1,0 +1,20 @@
+import 'package:coal/utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Scroll', () {
+    test('scrolls vertically', () {
+      expect(scrollUp(), '\x1B[S');
+      expect(scrollUp(2), '\x1B[S\x1B[S');
+      expect(scrollDown(), '\x1B[T');
+      expect(scrollDown(2), '\x1B[T\x1B[T');
+    });
+
+    test('scrolls horizontally', () {
+      expect(scrollLeft(), '\x1B[ @');
+      expect(scrollLeft(2), '\x1B[ @\x1B[ @');
+      expect(scrollRight(), '\x1B[ A');
+      expect(scrollRight(2), '\x1B[ A\x1B[ A');
+    });
+  });
+}

--- a/test/utils/text_width_test.dart
+++ b/test/utils/text_width_test.dart
@@ -1,6 +1,68 @@
 import 'package:coal/utils.dart';
-import 'package:oxy/oxy.dart';
 import 'package:test/test.dart';
+
+const basicEmojiSamples = [
+  '😀',
+  '😃',
+  '😄',
+  '😁',
+  '😆',
+  '🥹',
+  '😅',
+  '😂',
+  '🤣',
+  '🥲',
+  '☺️',
+  '😊',
+  '😇',
+  '🙂',
+  '🙃',
+  '😉',
+  '😌',
+  '😍',
+  '🥰',
+  '😘',
+  '😗',
+  '😙',
+  '😚',
+  '😋',
+  '😛',
+  '😝',
+  '😜',
+  '🤪',
+  '🤨',
+  '🧐',
+  '🤓',
+  '😎',
+  '🥳',
+  '🤯',
+  '😤',
+  '😭',
+  '😱',
+  '🤔',
+  '🤗',
+  '🫡',
+  '👍',
+  '👎',
+  '👏',
+  '🙏',
+  '💪',
+  '🧠',
+  '👀',
+  '🫶',
+  '❤️',
+  '🔥',
+  '✨',
+  '🎉',
+  '✅',
+  '🚀',
+  '🐛',
+  '🍎',
+  '⚽',
+  '🏆',
+  '💻',
+  '📦',
+];
 
 num getWidth(
   String input, {
@@ -140,12 +202,8 @@ void main() {
         expect(getWidth('🇺🇳' * 2), 4);
       });
 
-      test('supports all basic emojis', () async {
-        final res = await oxy.get(
-          'https://raw.githubusercontent.com/muan/unicode-emoji-json/refs/heads/main/data-by-emoji.json',
-        );
-        final data = await res.json();
-        for (final String emoji in Map.from(data).keys) {
+      test('supports representative basic emojis', () {
+        for (final emoji in basicEmojiSamples) {
           expect(getWidth(emoji), 2);
         }
       });


### PR DESCRIPTION
## Summary
- stabilize Coal 0.0.7 release baseline, docs, CI gates, examples, and TAB/runtime regressions
- add narrow Coal CLI with `coal complete`, `coal dart-complete`, and `coal doctor`
- add Keypass decoding/parsing/dispatch primitives and Readline line editing core without stdin/raw-mode ownership
- keep Prompt and Prompt Utils deferred in the roadmap until higher-level prompt use cases are proven

Closes #11
Closes #12
Closes #13
Closes #16

## Verification
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test --exclude-tags=script-runtime`
- `dart test --tags=script-runtime`
- `dart pub publish --dry-run` (0 warnings)
- `dart compile exe bin/coal.dart -o /tmp/coal-smoke && /tmp/coal-smoke doctor`

## Issue Notes
- #14 remains deferred until Prompt can build on stable Readline contracts.
- #15 remains future/deferred until Prompt exists and repeated utility needs are proven.
- #2 remains Renovate-managed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.0.7

* **New Features**
  * Added `coal` CLI tool with shell completion generation and diagnostic commands.
  * Introduced Keypass module for terminal key input parsing and event dispatching.
  * Introduced Readline module with line editing, history, and buffer management.
  * Enhanced shell completion scripts with customizable completion commands.

* **Bug Fixes**
  * Fixed Args parsing for empty input with default values.
  * Corrected ANSI scroll command escape sequences.

* **Documentation**
  * Expanded README with new module guides and updated examples.
  * Added project roadmap and shell completion maintenance documentation.

* **Tests**
  * Added comprehensive test suites for CLI, Keypass, and Readline functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->