### PR TITLE
feat(keypass): add key binding dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- feat(keypass): add terminal key binding dispatch.
 - feat(tab): add Dart SDK command completion setup.
 - docs(tab): document upstream sync and test strategy.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ plain Dart CLIs or existing command packages.
 | Entry | Description |
 |:----|:----|
 | [`package:coal/args.dart`](#args-parser) | Lightweight command-line argument parsing. |
+| [`package:coal/keypass.dart`](#keypass) | Terminal key sequence decoding and binding dispatch. |
 | [`package:coal/utils.dart`](#ansi-utility) | ANSI escape-code and terminal text helpers. |
 | [`package:coal/tab.dart`](#tab) | Shell completion definitions and script generation. |
 | [`package:coal/tab/args.dart`](example/README.md#args-adapter) | Adapter for `package:args` `CommandRunner` apps. |
@@ -18,6 +19,22 @@ plain Dart CLIs or existing command packages.
 
 ```bash
 dart pub add coal
+```
+
+## Keypass
+
+Decode complete terminal key sequences and dispatch key bindings:
+
+```dart
+import 'package:coal/keypass.dart';
+
+final keys = Keypass();
+
+keys.bind('ctrl+c', (event) => print('cancel'));
+keys.bind('up', (event) => print('history up'));
+
+keys.handleSequence('\x03'); // ctrl+c
+keys.handleSequence('\x1b[A'); // up
 ```
 
 ## \<TAB\>

--- a/lib/keypass.dart
+++ b/lib/keypass.dart
@@ -1,0 +1,2 @@
+export 'src/keypass/key_event.dart';
+export 'src/keypass/keypass.dart';

--- a/lib/src/keypass/key_binding.dart
+++ b/lib/src/keypass/key_binding.dart
@@ -1,0 +1,133 @@
+String normalizeKeyBinding(String binding) {
+  final source = binding.trim();
+  if (source.isEmpty) {
+    throw const FormatException('Key binding cannot be empty.');
+  }
+
+  var ctrl = false;
+  var meta = false;
+  var shift = false;
+  String? key;
+
+  for (final part in splitKeyBinding(source)) {
+    final lower = part.toLowerCase();
+    switch (lower) {
+      case 'ctrl':
+      case 'control':
+      case 'ctl':
+        ctrl = true;
+      case 'meta':
+      case 'alt':
+      case 'option':
+      case 'cmd':
+      case 'command':
+        meta = true;
+      case 'shift':
+        shift = true;
+      default:
+        if (key != null) {
+          throw const FormatException(
+            'Key binding must contain exactly one key token.',
+          );
+        }
+        key = normalizeKeyToken(part);
+        if (part.length == 1 && isAsciiUpper(part.codeUnitAt(0))) {
+          shift = true;
+        }
+    }
+  }
+
+  if (key == null) {
+    throw const FormatException('Key binding must contain a key token.');
+  }
+
+  return composeKeyBinding(key: key, ctrl: ctrl, meta: meta, shift: shift);
+}
+
+List<String> splitKeyBinding(String source) {
+  if (source == '+') return const ['+'];
+
+  final parts = source.split('+').map((part) => part.trim()).toList();
+  if (parts.length > 2 &&
+      parts.last.isEmpty &&
+      parts[parts.length - 2].isEmpty) {
+    return [...parts.take(parts.length - 2), '+'];
+  }
+
+  if (parts.any((part) => part.isEmpty)) {
+    throw const FormatException('Key binding contains an empty token.');
+  }
+  return parts;
+}
+
+String composeKeyBinding({
+  required String key,
+  required bool ctrl,
+  required bool meta,
+  required bool shift,
+}) {
+  final parts = <String>[
+    if (ctrl) 'ctrl',
+    if (meta) 'meta',
+    if (shift) 'shift',
+    normalizeKeyToken(key),
+  ];
+  return parts.join('+');
+}
+
+String normalizeKeyToken(String key) {
+  final normalized = key.trim().toLowerCase();
+  if (normalized.isEmpty) {
+    throw const FormatException('Key token cannot be empty.');
+  }
+
+  final aliased = switch (normalized) {
+    '+' || 'plus' => 'plus',
+    'esc' || 'escape' => 'escape',
+    'return' || 'enter' => 'enter',
+    'space' || 'spacebar' => 'space',
+    'backspace' || 'bs' => 'backspace',
+    'del' || 'delete' => 'delete',
+    'ins' || 'insert' => 'insert',
+    'pgup' || 'pageup' => 'pageup',
+    'pgdn' || 'pgdown' || 'pagedown' => 'pagedown',
+    'arrowup' || 'up' => 'up',
+    'arrowdown' || 'down' => 'down',
+    'arrowleft' || 'left' => 'left',
+    'arrowright' || 'right' => 'right',
+    _ => normalized,
+  };
+
+  if (isKnownKeyName(aliased) || aliased.runes.length == 1) {
+    return aliased;
+  }
+  throw FormatException('Unsupported key token: $key');
+}
+
+bool isKnownKeyName(String key) {
+  if (_knownKeyNames.contains(key)) return true;
+  if (!key.startsWith('f')) return false;
+  final number = int.tryParse(key.substring(1));
+  return number != null && number >= 1 && number <= 12;
+}
+
+bool isAsciiUpper(int unit) => unit >= 65 && unit <= 90;
+
+const _knownKeyNames = <String>{
+  'backspace',
+  'delete',
+  'down',
+  'end',
+  'enter',
+  'escape',
+  'home',
+  'insert',
+  'left',
+  'pagedown',
+  'pageup',
+  'plus',
+  'right',
+  'space',
+  'tab',
+  'up',
+};

--- a/lib/src/keypass/key_decoder.dart
+++ b/lib/src/keypass/key_decoder.dart
@@ -1,0 +1,211 @@
+part of 'key_event.dart';
+
+KeyEvent _decodeKeyEvent(String sequence) {
+  if (sequence.isEmpty) {
+    throw const FormatException('Key sequence cannot be empty.');
+  }
+
+  if (_simpleSequenceMap[sequence] case final key?) {
+    return key.toEvent(sequence);
+  }
+
+  if (sequence.startsWith('\x1b[') && sequence.length > 2) {
+    final decoded = _decodeCsi(sequence);
+    if (decoded == null) {
+      throw FormatException('Unsupported CSI key sequence: $sequence');
+    }
+    return decoded.toEvent(sequence);
+  }
+
+  if (sequence.startsWith('\x1bO') && sequence.length > 2) {
+    final decoded = _decodeSs3(sequence);
+    if (decoded == null) {
+      throw FormatException('Unsupported SS3 key sequence: $sequence');
+    }
+    return decoded.toEvent(sequence);
+  }
+
+  if (sequence.startsWith('\x1b') && sequence.length > 1) {
+    final nested = _decodeKeyEvent(sequence.substring(1));
+    return KeyEvent(
+      sequence: sequence,
+      key: nested.key,
+      ctrl: nested.ctrl,
+      meta: true,
+      shift: nested.shift,
+    );
+  }
+
+  if (sequence.runes.length != 1) {
+    throw FormatException('Unsupported key sequence: $sequence');
+  }
+
+  final codePoint = sequence.runes.single;
+  if (codePoint == 0) {
+    return const KeyEvent(sequence: '\x00', key: 'space', ctrl: true);
+  }
+  if (codePoint >= 1 && codePoint <= 26) {
+    return KeyEvent(
+      sequence: sequence,
+      key: String.fromCharCode(codePoint + 96),
+      ctrl: true,
+    );
+  }
+
+  final char = String.fromCharCode(codePoint);
+  if (char == '+') return KeyEvent(sequence: sequence, key: 'plus');
+  // Only single-code-unit ASCII uppercase letters imply Shift; supplementary
+  // characters stay literal text input.
+  final shift = char.length == 1 && isAsciiUpper(char.codeUnitAt(0));
+  return KeyEvent(
+    sequence: sequence,
+    key: shift ? char.toLowerCase() : char,
+    shift: shift,
+  );
+}
+
+_DecodedKey? _decodeCsi(String sequence) {
+  if (!sequence.startsWith('\x1b[') || sequence.length < 3) return null;
+
+  final payload = sequence.substring(2);
+  final finalChar = payload.substring(payload.length - 1);
+  final paramsRaw = payload.substring(0, payload.length - 1);
+  if (paramsRaw.isNotEmpty && !RegExp(r'^[0-9;]+$').hasMatch(paramsRaw)) {
+    return null;
+  }
+
+  final params = <int>[];
+  if (paramsRaw.isNotEmpty) {
+    for (final part in paramsRaw.split(';')) {
+      if (part.isEmpty) return null;
+      final value = int.tryParse(part);
+      if (value == null) return null;
+      params.add(value);
+    }
+  }
+
+  if (finalChar == '~') {
+    if (params.isEmpty) return null;
+    final key = _tildeKeyCodes[params.first];
+    if (key == null) return null;
+
+    final modifier = params.length > 1 ? params[1] : 1;
+    final flags = _decodeModifier(modifier);
+    return _DecodedKey(
+      key,
+      ctrl: flags.ctrl,
+      meta: flags.meta,
+      shift: flags.shift,
+    );
+  }
+
+  final base = _csiFinalMap[finalChar];
+  if (base == null) return null;
+
+  var modifier = 1;
+  if (params.length > 1) {
+    modifier = params[1];
+  } else if (params.length == 1 && params.single > 1) {
+    modifier = params.single;
+  }
+
+  final flags = _decodeModifier(modifier);
+  return _DecodedKey(
+    base.key,
+    ctrl: base.ctrl || flags.ctrl,
+    meta: base.meta || flags.meta,
+    shift: base.shift || flags.shift,
+  );
+}
+
+_DecodedKey? _decodeSs3(String sequence) {
+  if (!sequence.startsWith('\x1bO') || sequence.length != 3) return null;
+  return _ss3FinalMap[sequence.substring(2)];
+}
+
+({bool ctrl, bool meta, bool shift}) _decodeModifier(int value) {
+  if (value < 1 || value > 8) {
+    throw FormatException('Unsupported CSI modifier value: $value');
+  }
+  if (value <= 1) return (ctrl: false, meta: false, shift: false);
+  final bits = value - 1;
+  return (ctrl: bits & 4 != 0, meta: bits & 2 != 0, shift: bits & 1 != 0);
+}
+
+final class _DecodedKey {
+  const _DecodedKey(
+    this.key, {
+    this.ctrl = false,
+    this.meta = false,
+    this.shift = false,
+  });
+
+  final String key;
+  final bool ctrl;
+  final bool meta;
+  final bool shift;
+
+  KeyEvent toEvent(String sequence) {
+    return KeyEvent(
+      sequence: sequence,
+      key: key,
+      ctrl: ctrl,
+      meta: meta,
+      shift: shift,
+    );
+  }
+}
+
+const _simpleSequenceMap = <String, _DecodedKey>{
+  '\b': _DecodedKey('backspace'),
+  '\t': _DecodedKey('tab'),
+  '\n': _DecodedKey('enter'),
+  '\r': _DecodedKey('enter'),
+  ' ': _DecodedKey('space'),
+  '\x1b': _DecodedKey('escape'),
+  '\x7f': _DecodedKey('backspace'),
+};
+
+const _csiFinalMap = <String, _DecodedKey>{
+  'A': _DecodedKey('up'),
+  'B': _DecodedKey('down'),
+  'C': _DecodedKey('right'),
+  'D': _DecodedKey('left'),
+  'F': _DecodedKey('end'),
+  'H': _DecodedKey('home'),
+  'P': _DecodedKey('f1'),
+  'Q': _DecodedKey('f2'),
+  'R': _DecodedKey('f3'),
+  'S': _DecodedKey('f4'),
+  'Z': _DecodedKey('tab', shift: true),
+};
+
+const _ss3FinalMap = <String, _DecodedKey>{
+  'A': _DecodedKey('up'),
+  'B': _DecodedKey('down'),
+  'C': _DecodedKey('right'),
+  'D': _DecodedKey('left'),
+  'F': _DecodedKey('end'),
+  'H': _DecodedKey('home'),
+  'P': _DecodedKey('f1'),
+  'Q': _DecodedKey('f2'),
+  'R': _DecodedKey('f3'),
+  'S': _DecodedKey('f4'),
+};
+
+const _tildeKeyCodes = <int, String>{
+  1: 'home',
+  2: 'insert',
+  3: 'delete',
+  4: 'end',
+  5: 'pageup',
+  6: 'pagedown',
+  15: 'f5',
+  17: 'f6',
+  18: 'f7',
+  19: 'f8',
+  20: 'f9',
+  21: 'f10',
+  23: 'f11',
+  24: 'f12',
+};

--- a/lib/src/keypass/key_event.dart
+++ b/lib/src/keypass/key_event.dart
@@ -1,0 +1,58 @@
+import 'key_binding.dart';
+
+part 'key_decoder.dart';
+
+/// A decoded terminal key sequence.
+///
+/// [sequence] is the original terminal sequence that produced the event.
+/// [binding] is the canonical key binding string used by [Keypass].
+final class KeyEvent {
+  /// Creates a key event.
+  const KeyEvent({
+    required this.sequence,
+    required this.key,
+    this.ctrl = false,
+    this.meta = false,
+    this.shift = false,
+  });
+
+  /// Decodes a complete terminal key sequence.
+  factory KeyEvent.fromSequence(String sequence) => _decodeKeyEvent(sequence);
+
+  /// The original terminal sequence.
+  final String sequence;
+
+  /// The normalized key token.
+  final String key;
+
+  /// Whether the Control modifier was pressed.
+  final bool ctrl;
+
+  /// Whether the Meta/Alt modifier was pressed.
+  final bool meta;
+
+  /// Whether the Shift modifier was pressed.
+  final bool shift;
+
+  /// Canonical key binding string.
+  String get binding =>
+      composeKeyBinding(key: key, ctrl: ctrl, meta: meta, shift: shift);
+
+  @override
+  bool operator ==(Object other) {
+    return other is KeyEvent &&
+        sequence == other.sequence &&
+        key == other.key &&
+        ctrl == other.ctrl &&
+        meta == other.meta &&
+        shift == other.shift;
+  }
+
+  @override
+  int get hashCode => Object.hash(sequence, key, ctrl, meta, shift);
+
+  @override
+  String toString() {
+    return 'KeyEvent(binding: $binding, sequence: $sequence)';
+  }
+}

--- a/lib/src/keypass/keypass.dart
+++ b/lib/src/keypass/keypass.dart
@@ -1,0 +1,52 @@
+import 'key_binding.dart';
+import 'key_event.dart';
+
+/// Handles a decoded key event.
+typedef KeyHandler = void Function(KeyEvent event);
+
+/// Key binding dispatcher for terminal flows.
+///
+/// [Keypass] operates on complete terminal key sequences. It does not read from
+/// stdin or buffer byte chunks; higher-level input modules can own that state.
+final class Keypass {
+  final Map<String, List<KeyHandler>> _handlers = {};
+
+  /// Registers [handler] for [binding].
+  ///
+  /// Bindings are normalized before storage, so `Ctrl + C` and `ctrl+c` match
+  /// the same key event.
+  void bind(String binding, KeyHandler handler) {
+    final normalized = normalizeKeyBinding(binding);
+    _handlers.putIfAbsent(normalized, () => <KeyHandler>[]).add(handler);
+  }
+
+  /// Removes all handlers for [binding].
+  ///
+  /// Returns `true` when a binding existed.
+  bool unbind(String binding) {
+    final normalized = normalizeKeyBinding(binding);
+    return _handlers.remove(normalized) != null;
+  }
+
+  /// Removes all bindings.
+  void clear() => _handlers.clear();
+
+  /// Dispatches [event] to matching handlers.
+  ///
+  /// Returns `true` when at least one handler matched. The current handler list
+  /// is copied before dispatch, so handlers can safely mutate bindings without
+  /// affecting the in-flight dispatch.
+  bool dispatch(KeyEvent event) {
+    final handlers = _handlers[event.binding];
+    if (handlers == null || handlers.isEmpty) return false;
+
+    for (final handler in List<KeyHandler>.from(handlers)) {
+      handler(event);
+    }
+    return true;
+  }
+
+  /// Decodes and dispatches a complete terminal key [sequence].
+  bool handleSequence(String sequence) =>
+      dispatch(KeyEvent.fromSequence(sequence));
+}

--- a/test/keypass_test.dart
+++ b/test/keypass_test.dart
@@ -1,0 +1,155 @@
+import 'package:coal/keypass.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('key event decoding', () {
+    test('decodes printable and control keys', () {
+      expect(KeyEvent.fromSequence('a').binding, 'a');
+      expect(KeyEvent.fromSequence('A').binding, 'shift+a');
+      expect(KeyEvent.fromSequence('+').binding, 'plus');
+      expect(KeyEvent.fromSequence(' ').binding, 'space');
+      expect(KeyEvent.fromSequence('\x03').binding, 'ctrl+c');
+    });
+
+    test('decodes named control keys', () {
+      expect(KeyEvent.fromSequence('\t').binding, 'tab');
+      expect(KeyEvent.fromSequence('\r').binding, 'enter');
+      expect(KeyEvent.fromSequence('\n').binding, 'enter');
+      expect(KeyEvent.fromSequence('\x1b').binding, 'escape');
+      expect(KeyEvent.fromSequence('\x7f').binding, 'backspace');
+    });
+
+    test('decodes terminal escape sequences', () {
+      expect(KeyEvent.fromSequence('\x1b[A').binding, 'up');
+      expect(KeyEvent.fromSequence('\x1b[B').binding, 'down');
+      expect(KeyEvent.fromSequence('\x1b[Z').binding, 'shift+tab');
+      expect(KeyEvent.fromSequence('\x1b[1;6A').binding, 'ctrl+shift+up');
+      expect(KeyEvent.fromSequence('\x1b[3~').binding, 'delete');
+      expect(KeyEvent.fromSequence('\x1bOP').binding, 'f1');
+    });
+
+    test('decodes meta modified keys', () {
+      expect(KeyEvent.fromSequence('\x1ba').binding, 'meta+a');
+      expect(KeyEvent.fromSequence('\x1b[').binding, 'meta+[');
+      expect(KeyEvent.fromSequence('\x1bO').binding, 'meta+shift+o');
+      expect(KeyEvent.fromSequence('\x1b\r').binding, 'meta+enter');
+    });
+
+    test('throws for unsupported sequences', () {
+      expect(() => KeyEvent.fromSequence(''), throwsFormatException);
+      expect(() => KeyEvent.fromSequence('ab'), throwsFormatException);
+      expect(() => KeyEvent.fromSequence('\x1b[999x'), throwsFormatException);
+      expect(() => KeyEvent.fromSequence('\x1b[1;9A'), throwsFormatException);
+    });
+
+    test('is a value object', () {
+      const first = KeyEvent(sequence: '\x03', key: 'c', ctrl: true);
+      const second = KeyEvent(sequence: '\x03', key: 'c', ctrl: true);
+
+      expect(first, second);
+      expect(first.hashCode, second.hashCode);
+      expect(first.toString(), contains('ctrl+c'));
+    });
+  });
+
+  group('keypass dispatch', () {
+    test('normalizes binding aliases', () {
+      final keypass = Keypass();
+      final events = <String>[];
+
+      keypass.bind('Shift + Ctrl + ArrowUp', (event) {
+        events.add(event.binding);
+      });
+      keypass.bind('alt + Enter', (event) {
+        events.add(event.binding);
+      });
+      keypass.bind('spacebar', (event) {
+        events.add(event.binding);
+      });
+      keypass.bind('ctrl++', (event) {
+        events.add(event.binding);
+      });
+      keypass.bind('plus', (event) {
+        events.add(event.binding);
+      });
+
+      expect(keypass.handleSequence('\x1b[1;6A'), isTrue);
+      expect(keypass.handleSequence('\x1b\r'), isTrue);
+      expect(keypass.handleSequence(' '), isTrue);
+      expect(keypass.handleSequence('+'), isTrue);
+      expect(
+        keypass.dispatch(
+          const KeyEvent(sequence: '+', key: 'plus', ctrl: true),
+        ),
+        isTrue,
+      );
+
+      expect(events, <String>[
+        'ctrl+shift+up',
+        'meta+enter',
+        'space',
+        'plus',
+        'ctrl+plus',
+      ]);
+    });
+
+    test('returns false for misses', () {
+      final keypass = Keypass()..bind('ctrl+c', (_) {});
+
+      expect(keypass.handleSequence('a'), isFalse);
+      expect(
+        keypass.dispatch(const KeyEvent(sequence: 'b', key: 'b')),
+        isFalse,
+      );
+    });
+
+    test('runs handlers in registration order', () {
+      final keypass = Keypass();
+      final calls = <int>[];
+
+      keypass.bind('tab', (_) => calls.add(1));
+      keypass.bind('tab', (_) => calls.add(2));
+
+      expect(keypass.handleSequence('\t'), isTrue);
+      expect(calls, <int>[1, 2]);
+    });
+
+    test('unbinds and clears bindings', () {
+      final keypass = Keypass()
+        ..bind('escape', (_) {})
+        ..bind('tab', (_) {});
+
+      expect(keypass.unbind('esc'), isTrue);
+      expect(keypass.handleSequence('\x1b'), isFalse);
+      expect(keypass.handleSequence('\t'), isTrue);
+
+      keypass.clear();
+      expect(keypass.handleSequence('\t'), isFalse);
+    });
+
+    test('allows handlers to mutate bindings during dispatch', () {
+      final keypass = Keypass();
+      final calls = <String>[];
+
+      keypass.bind('a', (_) {
+        calls.add('first');
+        keypass.unbind('a');
+      });
+      keypass.bind('a', (_) => calls.add('second'));
+
+      expect(keypass.handleSequence('a'), isTrue);
+      expect(calls, <String>['first', 'second']);
+      expect(keypass.handleSequence('a'), isFalse);
+    });
+
+    test('rejects invalid bindings', () {
+      final keypass = Keypass();
+
+      expect(() => keypass.bind('', (_) {}), throwsFormatException);
+      expect(() => keypass.bind('ctrl+meta', (_) {}), throwsFormatException);
+      expect(() => keypass.bind('ctrl+a+b', (_) {}), throwsFormatException);
+      expect(() => keypass.bind('unknown-key', (_) {}), throwsFormatException);
+      expect(() => keypass.bind('ctrl+', (_) {}), throwsFormatException);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add `package:coal/keypass.dart` with a small key binding dispatcher API.
- Decode complete terminal key sequences into immutable `KeyEvent` values.
- Support core bindings for printable keys, control keys, Escape/Meta, arrows, shift-tab, delete, and basic function keys.
- Add focused tests and README usage documentation.

Closes #12

## Design Notes

- This intentionally does not expose stdin, stream, or byte-chunk parsing APIs. Readline should own buffering and partial terminal input state in #13.
- Internal binding normalization and decoder helpers are not exported; public API is limited to `KeyEvent`, `Keypass`, and `KeyHandler`.
- The old closed PR #23 was reviewed as prior art, but this implementation avoids its larger public surface and unreliable `listenBytes` path.

## Review

- Subagent review of old PR #23 identified stream parser/API-size risks.
- Subagent review of this implementation found one P2 around `ESC [` / `ESC O` Meta fallback and one P3 around CSI modifier validation. Both were fixed and re-reviewed with no remaining P1/P2.

## Validation

- `dart format --set-exit-if-changed .`
- `dart analyze`
- `dart test test/keypass_test.dart --reporter expanded`
- `dart test --exclude-tags=script-runtime --reporter compact`
- `dart test --tags=script-runtime --reporter compact`
- `dart pub publish --dry-run` (0 warnings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Keypass module for terminal key sequence binding and dispatch functionality, enabling users to bind key combinations to custom handlers and dispatch events.

* **Documentation**
  * Updated README with Keypass feature description and usage example.
  * Added changelog entry documenting the new key binding dispatch capability.

* **Tests**
  * Added comprehensive test suite for key event decoding and handler dispatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->