### PR TITLE
feat(readline): add interactive input handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- feat(readline): add interactive line input handling.
 - feat(keypass): add terminal key binding dispatch.
 - feat(tab): add Dart SDK command completion setup.
 - docs(tab): document upstream sync and test strategy.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ plain Dart CLIs or existing command packages.
 |:----|:----|
 | [`package:coal/args.dart`](#args-parser) | Lightweight command-line argument parsing. |
 | [`package:coal/keypass.dart`](#keypass) | Terminal key sequence decoding and binding dispatch. |
+| [`package:coal/readline.dart`](#readline) | Interactive line input with editing keys and history. |
 | [`package:coal/utils.dart`](#ansi-utility) | ANSI escape-code and terminal text helpers. |
 | [`package:coal/tab.dart`](#tab) | Shell completion definitions and script generation. |
 | [`package:coal/tab/args.dart`](example/README.md#args-adapter) | Adapter for `package:args` `CommandRunner` apps. |
@@ -35,6 +36,25 @@ keys.bind('up', (event) => print('history up'));
 
 keys.handleSequence('\x03'); // ctrl+c
 keys.handleSequence('\x1b[A'); // up
+```
+
+## Readline
+
+Read one edited line from a terminal:
+
+```dart
+import 'package:coal/readline.dart';
+
+Future<void> main() async {
+  final readline = Readline.stdio();
+
+  try {
+    final name = await readline.readLine(prompt: 'Name: ');
+    print('Hello, ${name ?? 'anonymous'}');
+  } finally {
+    await readline.close();
+  }
+}
 ```
 
 ## \<TAB\>

--- a/lib/readline.dart
+++ b/lib/readline.dart
@@ -1,0 +1,1 @@
+export 'src/readline/readline.dart' show Readline;

--- a/lib/src/readline/history.dart
+++ b/lib/src/readline/history.dart
@@ -1,0 +1,63 @@
+final class LineHistory {
+  LineHistory({int limit = 100, Iterable<String> entries = const <String>[]})
+    : _limit = limit {
+    if (limit < 0) {
+      throw ArgumentError.value(
+        limit,
+        'limit',
+        'History limit cannot be negative.',
+      );
+    }
+    for (final entry in entries) {
+      add(entry);
+    }
+  }
+
+  final int _limit;
+  final List<String> _entries = <String>[];
+  int? _cursor;
+  String? _draft;
+
+  void add(String line) {
+    if (_limit == 0 || line.isEmpty) return;
+    if (_entries.isNotEmpty && _entries.last == line) return;
+
+    _entries.add(line);
+    while (_entries.length > _limit) {
+      _entries.removeAt(0);
+    }
+    resetNavigation();
+  }
+
+  String? previous(String currentLine) {
+    if (_entries.isEmpty) return null;
+
+    if (_cursor == null) {
+      _draft = currentLine;
+      _cursor = _entries.length - 1;
+    } else if (_cursor! > 0) {
+      _cursor = _cursor! - 1;
+    }
+
+    return _entries[_cursor!];
+  }
+
+  String? next() {
+    final cursor = _cursor;
+    if (cursor == null) return null;
+
+    if (cursor < _entries.length - 1) {
+      _cursor = cursor + 1;
+      return _entries[_cursor!];
+    }
+
+    final draft = _draft ?? '';
+    resetNavigation();
+    return draft;
+  }
+
+  void resetNavigation() {
+    _cursor = null;
+    _draft = null;
+  }
+}

--- a/lib/src/readline/input_parser.dart
+++ b/lib/src/readline/input_parser.dart
@@ -1,0 +1,184 @@
+import 'dart:async';
+import 'dart:convert';
+
+import '../keypass/key_event.dart';
+
+sealed class ReadlineInput {
+  const ReadlineInput();
+}
+
+final class ReadlineTextInput extends ReadlineInput {
+  const ReadlineTextInput(this.text);
+
+  final String text;
+}
+
+final class ReadlineKeyInput extends ReadlineInput {
+  const ReadlineKeyInput(this.event);
+
+  final KeyEvent event;
+}
+
+final class ReadlineInputParser {
+  ReadlineInputParser({
+    required void Function(ReadlineInput input) emit,
+    Duration escapeTimeout = const Duration(milliseconds: 80),
+  }) : _emit = emit,
+       _escapeTimeout = escapeTimeout {
+    _textSink = const Utf8Decoder().startChunkedConversion(
+      _DecodedTextSink(_emitText),
+    );
+  }
+
+  final void Function(ReadlineInput input) _emit;
+  final Duration _escapeTimeout;
+  late final ByteConversionSink _textSink;
+  final List<int> _escape = <int>[];
+  Timer? _escapeTimer;
+  bool _closed = false;
+
+  void add(List<int> bytes) {
+    if (_closed) {
+      throw StateError('Readline input parser is closed.');
+    }
+
+    for (final byte in bytes) {
+      _addByte(byte);
+    }
+  }
+
+  void close() {
+    if (_closed) return;
+    _closed = true;
+    _flushEscape();
+    try {
+      _textSink.close();
+    } on FormatException {
+      // Drop an incomplete trailing UTF-8 scalar instead of failing after EOF.
+    }
+  }
+
+  void _startEscape() {
+    _escape.add(0x1b);
+    _resetEscapeTimer();
+  }
+
+  void _addByte(int byte) {
+    if (_escape.isNotEmpty) {
+      _addEscapeByte(byte);
+      return;
+    }
+
+    if (byte == 0x1b) {
+      _startEscape();
+    } else if (_isControlByte(byte)) {
+      _emitKey(String.fromCharCode(byte));
+    } else {
+      _textSink.add(<int>[byte]);
+    }
+  }
+
+  void _addEscapeByte(int byte) {
+    if (_isTerminalControlPrefix(_escape) &&
+        !_canContinueTerminalControl(_escape, byte)) {
+      _flushEscape();
+      _addByte(byte);
+      return;
+    }
+
+    _escape.add(byte);
+    if (_isCompleteEscape(_escape)) {
+      _flushEscape();
+    } else if (_isTerminalControlPrefix(_escape)) {
+      _escapeTimer?.cancel();
+      _escapeTimer = null;
+    } else {
+      _resetEscapeTimer();
+    }
+  }
+
+  void _resetEscapeTimer() {
+    _escapeTimer?.cancel();
+    _escapeTimer = Timer(_escapeTimeout, _flushEscape);
+  }
+
+  void _flushEscape() {
+    if (_escape.isEmpty) return;
+    _escapeTimer?.cancel();
+    _escapeTimer = null;
+
+    final sequence = String.fromCharCodes(_escape);
+    _escape.clear();
+    _emitKey(sequence);
+  }
+
+  void _emitText(String text) {
+    if (text.isNotEmpty) {
+      _emit(ReadlineTextInput(text));
+    }
+  }
+
+  void _emitKey(String sequence) {
+    try {
+      _emit(ReadlineKeyInput(KeyEvent.fromSequence(sequence)));
+    } on FormatException {
+      // Ignore terminal sequences that Keypass does not model yet.
+    }
+  }
+}
+
+bool _isControlByte(int byte) => byte < 0x20 || byte == 0x7f;
+
+bool _isCompleteEscape(List<int> bytes) {
+  if (bytes.length < 2) return false;
+
+  final second = bytes[1];
+  if (second == 0x5b) {
+    if (bytes.length == 2) return false;
+    final finalByte = bytes.last;
+    return finalByte >= 0x40 && finalByte <= 0x7e;
+  }
+
+  if (second == 0x4f) {
+    return bytes.length == 3;
+  }
+
+  return bytes.length == 2;
+}
+
+bool _isTerminalControlPrefix(List<int> bytes) {
+  return bytes.length >= 2 && (bytes[1] == 0x5b || bytes[1] == 0x4f);
+}
+
+bool _canContinueTerminalControl(List<int> bytes, int byte) {
+  final second = bytes[1];
+  if (second == 0x5b) {
+    return byte >= 0x20 && byte <= 0x7e;
+  }
+  if (second == 0x4f) {
+    return bytes.length == 2 && byte >= 0x40 && byte <= 0x7e;
+  }
+  return false;
+}
+
+final class _DecodedTextSink extends StringConversionSink {
+  _DecodedTextSink(this._emit);
+
+  final void Function(String text) _emit;
+
+  @override
+  void add(String str) {
+    _emit(str);
+  }
+
+  @override
+  void addSlice(String str, int start, int end, bool isLast) {
+    if (start < end) {
+      add(str.substring(start, end));
+    }
+    if (isLast) close();
+  }
+
+  @override
+  void close() {}
+}

--- a/lib/src/readline/input_queue.dart
+++ b/lib/src/readline/input_queue.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'input_parser.dart';
+
+final class ReadlineInputQueue {
+  ReadlineInputQueue(
+    Stream<List<int>> input, {
+    Duration escapeTimeout = const Duration(milliseconds: 80),
+  }) : _input = input {
+    _parser = ReadlineInputParser(emit: _add, escapeTimeout: escapeTimeout);
+  }
+
+  final Stream<List<int>> _input;
+  final Queue<ReadlineInput> _events = Queue<ReadlineInput>();
+  final Queue<Completer<ReadlineInput?>> _waiters =
+      Queue<Completer<ReadlineInput?>>();
+  late final ReadlineInputParser _parser;
+  StreamSubscription<List<int>>? _subscription;
+  Object? _error;
+  StackTrace? _stackTrace;
+  bool _done = false;
+
+  Future<ReadlineInput?> next() {
+    _listen();
+
+    if (_events.isNotEmpty) {
+      return Future<ReadlineInput?>.value(_events.removeFirst());
+    }
+    if (_error case final error?) {
+      return Future<ReadlineInput?>.error(error, _stackTrace);
+    }
+    if (_done) {
+      return Future<ReadlineInput?>.value();
+    }
+
+    final completer = Completer<ReadlineInput?>();
+    _waiters.add(completer);
+    return completer.future;
+  }
+
+  Future<void> close() async {
+    await _subscription?.cancel();
+    _subscription = null;
+    _parser.close();
+    _done = true;
+    while (_waiters.isNotEmpty) {
+      _waiters.removeFirst().complete();
+    }
+  }
+
+  void _listen() {
+    _subscription ??= _input.listen(
+      _parser.add,
+      onError: _fail,
+      onDone: _finish,
+      cancelOnError: false,
+    );
+  }
+
+  void _add(ReadlineInput input) {
+    if (_waiters.isNotEmpty) {
+      _waiters.removeFirst().complete(input);
+    } else {
+      _events.add(input);
+    }
+  }
+
+  void _fail(Object error, StackTrace stackTrace) {
+    _error = error;
+    _stackTrace = stackTrace;
+    while (_waiters.isNotEmpty) {
+      _waiters.removeFirst().completeError(error, stackTrace);
+    }
+  }
+
+  void _finish() {
+    _parser.close();
+    _done = true;
+    while (_waiters.isNotEmpty) {
+      _waiters.removeFirst().complete();
+    }
+  }
+}

--- a/lib/src/readline/line_buffer.dart
+++ b/lib/src/readline/line_buffer.dart
@@ -1,0 +1,83 @@
+import 'package:characters/characters.dart';
+
+import '../utils/text_width.dart';
+
+final class LineBuffer {
+  final List<String> _chars = <String>[];
+
+  int cursor = 0;
+
+  bool get isEmpty => _chars.isEmpty;
+
+  String get text => _chars.join();
+
+  String get beforeCursor => _chars.take(cursor).join();
+
+  int get width => getTextWidth(text).toInt();
+
+  int get widthBeforeCursor => getTextWidth(beforeCursor).toInt();
+
+  void replace(String value) {
+    _chars
+      ..clear()
+      ..addAll(value.characters);
+    cursor = _chars.length;
+  }
+
+  void insert(String value) {
+    for (final char in value.characters) {
+      _chars.insert(cursor, char);
+      cursor += 1;
+    }
+  }
+
+  bool deleteBeforeCursor() {
+    if (cursor == 0) return false;
+    _chars.removeAt(cursor - 1);
+    cursor -= 1;
+    return true;
+  }
+
+  bool deleteAtCursor() {
+    if (cursor >= _chars.length) return false;
+    _chars.removeAt(cursor);
+    return true;
+  }
+
+  bool clearBeforeCursor() {
+    if (cursor == 0) return false;
+    _chars.removeRange(0, cursor);
+    cursor = 0;
+    return true;
+  }
+
+  bool clearAfterCursor() {
+    if (cursor >= _chars.length) return false;
+    _chars.removeRange(cursor, _chars.length);
+    return true;
+  }
+
+  bool moveLeft() {
+    if (cursor == 0) return false;
+    cursor -= 1;
+    return true;
+  }
+
+  bool moveRight() {
+    if (cursor >= _chars.length) return false;
+    cursor += 1;
+    return true;
+  }
+
+  bool moveHome() {
+    if (cursor == 0) return false;
+    cursor = 0;
+    return true;
+  }
+
+  bool moveEnd() {
+    if (cursor == _chars.length) return false;
+    cursor = _chars.length;
+    return true;
+  }
+}

--- a/lib/src/readline/readline.dart
+++ b/lib/src/readline/readline.dart
@@ -1,0 +1,238 @@
+import 'dart:async';
+import 'dart:io' as io;
+
+import '../keypass/key_event.dart';
+import 'history.dart';
+import 'input_parser.dart';
+import 'input_queue.dart';
+import 'line_buffer.dart';
+import 'renderer.dart';
+import 'terminal_mode.dart';
+
+/// Interactive line input with editing-friendly terminal behavior.
+final class Readline {
+  /// Creates a readline instance from injected input and output streams.
+  Readline({
+    required Stream<List<int>> input,
+    required StringSink output,
+    int historyLimit = 100,
+    Iterable<String> history = const <String>[],
+  }) : this._(
+         input: input,
+         output: output,
+         historyLimit: historyLimit,
+         history: history,
+         terminalColumns: 80,
+       );
+
+  Readline._({
+    required Stream<List<int>> input,
+    required StringSink output,
+    required int historyLimit,
+    required Iterable<String> history,
+    required int terminalColumns,
+    TerminalMode? terminalMode,
+  }) : _input = ReadlineInputQueue(input),
+       _output = output,
+       _terminalMode = terminalMode,
+       _terminalColumns = terminalColumns,
+       _history = LineHistory(limit: historyLimit, entries: history);
+
+  /// Creates a readline instance backed by process stdio.
+  factory Readline.stdio({
+    io.Stdin? input,
+    StringSink? output,
+    int historyLimit = 100,
+    Iterable<String> history = const <String>[],
+  }) {
+    final stdin = input ?? io.stdin;
+    final stdout = output ?? io.stdout;
+    return Readline._(
+      input: stdin,
+      output: stdout,
+      historyLimit: historyLimit,
+      history: history,
+      terminalColumns: _outputTerminalColumns(stdout),
+      terminalMode: StdinTerminalMode(stdin),
+    );
+  }
+
+  final ReadlineInputQueue _input;
+  final StringSink _output;
+  final TerminalMode? _terminalMode;
+  final int _terminalColumns;
+  final LineHistory _history;
+  bool _reading = false;
+  bool _closed = false;
+
+  /// Reads one edited line.
+  ///
+  /// Returns `null` when input ends, Ctrl-D is pressed on an empty line, or the
+  /// line is cancelled with Ctrl-C.
+  Future<String?> readLine({String prompt = ''}) async {
+    if (_closed) {
+      throw StateError('Readline is closed.');
+    }
+    if (_reading) {
+      throw StateError('Readline is already reading.');
+    }
+
+    _reading = true;
+    final buffer = LineBuffer();
+    final renderer = LineRenderer(
+      output: _output,
+      prompt: prompt,
+      terminalColumns: _terminalColumns,
+    );
+
+    try {
+      _terminalMode?.enterRawMode();
+      renderer.render(buffer);
+      await _flushOutput();
+
+      while (true) {
+        final input = await _input.next();
+        if (input == null) {
+          renderer.finishLine();
+          if (buffer.isEmpty) return null;
+          final line = buffer.text;
+          _history.add(line);
+          return line;
+        }
+
+        switch (input) {
+          case ReadlineTextInput(:final text):
+            buffer.insert(text);
+            _history.resetNavigation();
+            renderer.render(buffer);
+          case ReadlineKeyInput(:final event):
+            final action = _handleKey(event, buffer, renderer);
+            switch (action) {
+              case _ReadlineContinue():
+                break;
+              case _ReadlineSubmit(:final line):
+                _history.add(line);
+                return line;
+              case _ReadlineCancel():
+                return null;
+            }
+        }
+
+        await _flushOutput();
+      }
+    } finally {
+      _terminalMode?.restore();
+      await _flushOutput();
+      _reading = false;
+    }
+  }
+
+  /// Stops reading from the input stream.
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    await _input.close();
+    _terminalMode?.restore();
+    await _flushOutput();
+  }
+
+  _ReadlineAction _handleKey(
+    KeyEvent event,
+    LineBuffer buffer,
+    LineRenderer renderer,
+  ) {
+    switch (event.binding) {
+      case 'enter':
+        renderer.finishLine();
+        return _ReadlineSubmit(buffer.text);
+      case 'ctrl+c':
+        renderer.finishLine();
+        return const _ReadlineCancel();
+      case 'ctrl+d':
+        if (buffer.isEmpty) {
+          renderer.finishLine();
+          return const _ReadlineCancel();
+        }
+        if (buffer.deleteAtCursor()) {
+          _history.resetNavigation();
+          renderer.render(buffer);
+        }
+      case 'backspace' || 'ctrl+h':
+        if (buffer.deleteBeforeCursor()) {
+          _history.resetNavigation();
+          renderer.render(buffer);
+        }
+      case 'delete':
+        if (buffer.deleteAtCursor()) {
+          _history.resetNavigation();
+          renderer.render(buffer);
+        }
+      case 'left' || 'ctrl+b':
+        if (buffer.moveLeft()) renderer.render(buffer);
+      case 'right' || 'ctrl+f':
+        if (buffer.moveRight()) renderer.render(buffer);
+      case 'home' || 'ctrl+a':
+        if (buffer.moveHome()) renderer.render(buffer);
+      case 'end' || 'ctrl+e':
+        if (buffer.moveEnd()) renderer.render(buffer);
+      case 'ctrl+u':
+        if (buffer.clearBeforeCursor()) {
+          _history.resetNavigation();
+          renderer.render(buffer);
+        }
+      case 'ctrl+k':
+        if (buffer.clearAfterCursor()) {
+          _history.resetNavigation();
+          renderer.render(buffer);
+        }
+      case 'up':
+        if (_history.previous(buffer.text) case final line?) {
+          buffer.replace(line);
+          renderer.render(buffer);
+        }
+      case 'down':
+        if (_history.next() case final line?) {
+          buffer.replace(line);
+          renderer.render(buffer);
+        }
+      case 'tab':
+        buffer.insert('\t');
+        _history.resetNavigation();
+        renderer.render(buffer);
+    }
+
+    return const _ReadlineContinue();
+  }
+
+  Future<void> _flushOutput() async {
+    final output = _output;
+    if (output is io.IOSink) {
+      await output.flush();
+    }
+  }
+}
+
+sealed class _ReadlineAction {
+  const _ReadlineAction();
+}
+
+final class _ReadlineContinue extends _ReadlineAction {
+  const _ReadlineContinue();
+}
+
+final class _ReadlineSubmit extends _ReadlineAction {
+  const _ReadlineSubmit(this.line);
+
+  final String line;
+}
+
+final class _ReadlineCancel extends _ReadlineAction {
+  const _ReadlineCancel();
+}
+
+int _outputTerminalColumns(StringSink output) {
+  if (output is io.Stdout && output.hasTerminal) {
+    return output.terminalColumns;
+  }
+  return 80;
+}

--- a/lib/src/readline/renderer.dart
+++ b/lib/src/readline/renderer.dart
@@ -1,0 +1,82 @@
+import '../utils/cursor.dart';
+import '../utils/erase.dart';
+import '../utils/text_width.dart';
+import 'line_buffer.dart';
+
+final class LineRenderer {
+  LineRenderer({
+    required StringSink output,
+    required String prompt,
+    required int terminalColumns,
+  }) : _output = output,
+       _prompt = prompt,
+       _terminalColumns = terminalColumns < 1 ? 1 : terminalColumns;
+
+  final StringSink _output;
+  final String _prompt;
+  final int _terminalColumns;
+  int _rows = 1;
+  int _cursorRow = 0;
+
+  void render(LineBuffer buffer) {
+    final promptWidth = getTextWidth(_prompt).toInt();
+    final lineWidth = promptWidth + buffer.width;
+    final cursorCell = promptWidth + buffer.widthBeforeCursor;
+    final rows = _rowsFor(lineWidth);
+    var cursorRow = cursorCell ~/ _terminalColumns;
+    var cursorColumn = cursorCell % _terminalColumns;
+    if (cursorCell > 0 && cursorCell == lineWidth && cursorColumn == 0) {
+      cursorRow -= 1;
+      cursorColumn = _terminalColumns - 1;
+    }
+
+    _moveToRenderStart();
+    _eraseRenderedRows();
+    _output
+      ..write(_prompt)
+      ..write(buffer.text);
+
+    _rows = rows;
+    _cursorRow = cursorRow.clamp(0, rows - 1);
+    _moveToRenderStart(fromRow: rows - 1);
+    if (_cursorRow > 0) {
+      _output.write(cursorDown(_cursorRow));
+    }
+    _output.write(cursorTo(cursorColumn));
+  }
+
+  void finishLine() {
+    final remainingRows = _rows - _cursorRow - 1;
+    if (remainingRows > 0) {
+      _output.write(cursorDown(remainingRows));
+    }
+    _output.write('\n');
+    _rows = 1;
+    _cursorRow = 0;
+  }
+
+  int _rowsFor(int width) {
+    return width <= 0 ? 1 : ((width - 1) ~/ _terminalColumns) + 1;
+  }
+
+  void _moveToRenderStart({int? fromRow}) {
+    final row = fromRow ?? _cursorRow;
+    if (row > 0) {
+      _output.write(cursorUp(row));
+    }
+    _output.write(cursorLeft);
+  }
+
+  void _eraseRenderedRows() {
+    for (var row = 0; row < _rows; row++) {
+      _output.write(eraseLine);
+      if (row < _rows - 1) {
+        _output.write(cursorDown());
+      }
+    }
+    if (_rows > 1) {
+      _output.write(cursorUp(_rows - 1));
+    }
+    _output.write(cursorLeft);
+  }
+}

--- a/lib/src/readline/terminal_mode.dart
+++ b/lib/src/readline/terminal_mode.dart
@@ -1,0 +1,55 @@
+import 'dart:io' as io;
+
+abstract interface class TerminalMode {
+  void enterRawMode();
+
+  void restore();
+}
+
+final class StdinTerminalMode implements TerminalMode {
+  StdinTerminalMode(this._stdin);
+
+  final io.Stdin _stdin;
+  bool? _lineMode;
+  bool? _echoMode;
+  bool _active = false;
+
+  @override
+  void enterRawMode() {
+    if (_active || !_stdin.hasTerminal) return;
+
+    _lineMode = _stdin.lineMode;
+    _echoMode = _stdin.echoMode;
+    try {
+      _stdin
+        ..lineMode = false
+        ..echoMode = false;
+      _active = true;
+    } catch (_) {
+      _restoreSavedModes();
+      rethrow;
+    }
+  }
+
+  @override
+  void restore() {
+    if (!_active) return;
+
+    _restoreSavedModes();
+    _active = false;
+  }
+
+  void _restoreSavedModes() {
+    final lineMode = _lineMode;
+    final echoMode = _echoMode;
+    if (lineMode != null) {
+      _stdin.lineMode = lineMode;
+    }
+    if (echoMode != null) {
+      _stdin.echoMode = echoMode;
+    }
+
+    _lineMode = null;
+    _echoMode = null;
+  }
+}

--- a/test/readline_test.dart
+++ b/test/readline_test.dart
@@ -1,0 +1,318 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:coal/readline.dart';
+import 'package:coal/src/readline/line_buffer.dart';
+import 'package:coal/src/readline/renderer.dart';
+import 'package:coal/utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('readline', () {
+    test('reads a submitted line with a prompt', () async {
+      final harness = _ReadlineHarness();
+      addTearDown(harness.close);
+
+      final line = harness.readLine(prompt: 'Name: ');
+      await harness.pump();
+      harness.addText('Ada\r');
+
+      expect(await line, 'Ada');
+      expect(
+        stripVTControlCharacters(harness.outputText),
+        contains('Name: Ada\n'),
+      );
+    });
+
+    test('handles split escape sequences and split utf8 text', () async {
+      final harness = _ReadlineHarness();
+      addTearDown(harness.close);
+
+      final line = harness.readLine();
+      await harness.pump();
+      harness.addText('ab');
+      harness.addBytes(<int>[0x1b, 0x5b]);
+      harness.addBytes(<int>[0x44]);
+
+      final wide = utf8.encode('中');
+      harness.addBytes(<int>[wide[0]]);
+      harness.addBytes(<int>[wide[1], wide[2]]);
+      harness.addText('\r');
+
+      expect(await line, 'a中b');
+    });
+
+    test('does not time out a split CSI sequence', () async {
+      final harness = _ReadlineHarness();
+      addTearDown(harness.close);
+
+      final line = harness.readLine();
+      await harness.pump();
+      harness.addText('ab');
+      harness.addBytes(<int>[0x1b, 0x5b]);
+      await Future<void>.delayed(const Duration(milliseconds: 120));
+      harness
+        ..addBytes(<int>[0x44])
+        ..addText('X\r');
+
+      expect(await line, 'aXb');
+    });
+
+    test('does not hang after an incomplete CSI prefix', () async {
+      final harness = _ReadlineHarness();
+      addTearDown(harness.close);
+
+      final line = harness.readLine();
+      await harness.pump();
+      harness
+        ..addText('x')
+        ..addBytes(<int>[0x1b, 0x5b])
+        ..addText('\r');
+
+      expect(await line.timeout(const Duration(milliseconds: 200)), 'x');
+    });
+
+    test('edits with arrows, backspace, and delete', () async {
+      final harness = _ReadlineHarness();
+      addTearDown(harness.close);
+
+      final line = harness.readLine();
+      await harness.pump();
+      harness
+        ..addText('abcd')
+        ..addText('\x1b[D')
+        ..addText('\x1b[D')
+        ..addBytes(<int>[0x7f])
+        ..addText('\x1b[3~')
+        ..addText('\r');
+
+      expect(await line, 'ad');
+    });
+
+    test('edits with control shortcuts', () async {
+      final harness = _ReadlineHarness();
+      addTearDown(harness.close);
+
+      final line = harness.readLine();
+      await harness.pump();
+      harness
+        ..addText('abc')
+        ..addText('\x1b[D')
+        ..addBytes(<int>[0x15]) // Ctrl-U.
+        ..addText('x')
+        ..addBytes(<int>[0x0b]) // Ctrl-K.
+        ..addText('\r');
+
+      expect(await line, 'x');
+    });
+
+    test('navigates history and restores the current draft', () async {
+      final harness = _ReadlineHarness(history: <String>['one', 'two']);
+      addTearDown(harness.close);
+
+      final first = harness.readLine();
+      await harness.pump();
+      harness
+        ..addText('draft')
+        ..addText('\x1b[A')
+        ..addText('\x1b[A')
+        ..addText('\x1b[B')
+        ..addText('\x1b[B')
+        ..addText('\r');
+
+      expect(await first, 'draft');
+
+      final second = harness.readLine();
+      await harness.pump();
+      harness
+        ..addText('\x1b[A')
+        ..addText('\r');
+
+      expect(await second, 'draft');
+    });
+
+    test('editing a history entry exits history navigation', () async {
+      final harness = _ReadlineHarness(history: <String>['one', 'two']);
+      addTearDown(harness.close);
+
+      final line = harness.readLine();
+      await harness.pump();
+      harness
+        ..addText('\x1b[A')
+        ..addBytes(<int>[0x7f])
+        ..addText('\x1b[B')
+        ..addText('\r');
+
+      expect(await line, 'tw');
+    });
+
+    test('returns null for cancel and eof', () async {
+      final cancel = _ReadlineHarness();
+      addTearDown(cancel.close);
+
+      final cancelled = cancel.readLine();
+      await cancel.pump();
+      cancel.addBytes(<int>[0x03]); // Ctrl-C.
+
+      expect(await cancelled, isNull);
+
+      final eof = _ReadlineHarness();
+      addTearDown(eof.close);
+
+      final ended = eof.readLine();
+      await eof.pump();
+      eof.addBytes(<int>[0x04]); // Ctrl-D on an empty line.
+
+      expect(await ended, isNull);
+    });
+
+    test('ctrl-d deletes forward when the line is not empty', () async {
+      final harness = _ReadlineHarness();
+      addTearDown(harness.close);
+
+      final line = harness.readLine();
+      await harness.pump();
+      harness
+        ..addText('ab')
+        ..addText('\x1b[D')
+        ..addBytes(<int>[0x04])
+        ..addText('\r');
+
+      expect(await line, 'a');
+    });
+
+    test('preserves queued bytes across sequential reads', () async {
+      final harness = _ReadlineHarness();
+      addTearDown(harness.close);
+
+      final first = harness.readLine();
+      await harness.pump();
+      harness.addText('first\rsecond\r');
+
+      expect(await first, 'first');
+      expect(await harness.readLine(), 'second');
+    });
+
+    test('submits buffered text when the input stream ends', () async {
+      final harness = _ReadlineHarness();
+      addTearDown(harness.close);
+
+      final line = harness.readLine();
+      await harness.pump();
+      harness.addText('partial');
+      await harness.endInput();
+
+      expect(await line, 'partial');
+    });
+
+    test('rejects concurrent reads and reads after close', () async {
+      final harness = _ReadlineHarness();
+      final pending = harness.readLine();
+      await harness.pump();
+
+      expect(harness.readline.readLine(), throwsStateError);
+
+      harness.addText('\r');
+      await pending;
+      await harness.close();
+
+      expect(harness.readline.readLine(), throwsStateError);
+    });
+
+    test('renderer clears all rows when redrawing wrapped input', () {
+      final output = StringBuffer();
+      final renderer = LineRenderer(
+        output: output,
+        prompt: '> ',
+        terminalColumns: 10,
+      );
+      final buffer = LineBuffer()..insert('123456789012345');
+
+      renderer.render(buffer);
+      output.clear();
+      buffer.deleteBeforeCursor();
+      renderer.render(buffer);
+
+      final redraw = output.toString();
+      expect(redraw, contains(cursorUp()));
+      expect(redraw, contains(cursorDown()));
+      expect(RegExp(RegExp.escape(eraseLine)).allMatches(redraw), hasLength(2));
+    });
+
+    test('renderer keeps an exact-width cursor at the row end', () {
+      final output = StringBuffer();
+      final renderer = LineRenderer(
+        output: output,
+        prompt: '> ',
+        terminalColumns: 10,
+      );
+      final buffer = LineBuffer()..insert('12345678');
+
+      renderer.render(buffer);
+
+      expect(output.toString(), endsWith(cursorTo(9)));
+    });
+
+    test('renderer places a wrapped boundary cursor before following text', () {
+      final output = StringBuffer();
+      final renderer = LineRenderer(
+        output: output,
+        prompt: '',
+        terminalColumns: 10,
+      );
+      final buffer = LineBuffer()
+        ..insert('12345678901')
+        ..moveLeft();
+
+      renderer.render(buffer);
+
+      expect(
+        output.toString(),
+        endsWith('${cursorUp()}$cursorLeft${cursorDown()}${cursorTo(0)}'),
+      );
+    });
+  });
+}
+
+final class _ReadlineHarness {
+  _ReadlineHarness({Iterable<String> history = const <String>[]}) {
+    readline = Readline(
+      input: _controller.stream,
+      output: _output,
+      history: history,
+    );
+  }
+
+  final _output = StringBuffer();
+  final _controller = StreamController<List<int>>();
+
+  late final Readline readline;
+
+  String get outputText => _output.toString();
+
+  Future<String?> readLine({String prompt = ''}) {
+    return readline.readLine(prompt: prompt);
+  }
+
+  void addText(String text) {
+    addBytes(utf8.encode(text));
+  }
+
+  void addBytes(List<int> bytes) {
+    _controller.add(bytes);
+  }
+
+  Future<void> endInput() {
+    return _controller.close();
+  }
+
+  Future<void> pump() async {
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  Future<void> close() async {
+    await readline.close();
+    await _controller.close();
+    _output.clear();
+  }
+}


### PR DESCRIPTION
## Summary

- add `package:coal/readline.dart` with a narrow `Readline` public API
- implement internal UTF-8/escape input parsing, line editing, history, raw-mode restore, and wrapped-line rendering
- document minimal usage and add focused regression coverage

Closes #13

## Validation

- `dart format --set-exit-if-changed .`
- `dart analyze`
- `dart test --exclude-tags=script-runtime --reporter compact`
- `dart test --tags=script-runtime --reporter compact`
- `dart pub publish --dry-run`
- subagent read-only review: no remaining P1/P2 findings