### PR TITLE
feat(prompt-utils): add confirm helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- feat(prompt-utils): add a confirm helper.
 - feat(prompt): add basic text prompt flow.
 - feat(readline): add interactive line input handling.
 - feat(keypass): add terminal key binding dispatch.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ plain Dart CLIs or existing command packages.
 | [`package:coal/args.dart`](#args-parser) | Lightweight command-line argument parsing. |
 | [`package:coal/keypass.dart`](#keypass) | Terminal key sequence decoding and binding dispatch. |
 | [`package:coal/prompt.dart`](#prompt) | Basic text prompt flow for terminal CLIs. |
+| [`package:coal/prompt_utils.dart`](#prompt-utils) | Reusable prompt helpers for common CLI questions. |
 | [`package:coal/readline.dart`](#readline) | Interactive line input with editing keys and history. |
 | [`package:coal/utils.dart`](#ansi-utility) | ANSI escape-code and terminal text helpers. |
 | [`package:coal/tab.dart`](#tab) | Shell completion definitions and script generation. |
@@ -52,6 +53,26 @@ Future<void> main() async {
   try {
     final name = await prompt.text('Name', defaultValue: 'anonymous');
     print('Hello, ${name ?? 'cancelled'}');
+  } finally {
+    await prompt.close();
+  }
+}
+```
+
+## Prompt Utils
+
+Use common prompt helpers on top of `Prompt`:
+
+```dart
+import 'package:coal/prompt.dart';
+import 'package:coal/prompt_utils.dart';
+
+Future<void> main() async {
+  final prompt = Prompt.stdio();
+
+  try {
+    final publish = await prompt.confirm('Publish?', defaultValue: false);
+    print(publish == true ? 'confirmed' : 'skipped');
   } finally {
     await prompt.close();
   }

--- a/lib/prompt_utils.dart
+++ b/lib/prompt_utils.dart
@@ -1,0 +1,1 @@
+export 'src/prompt_utils/prompt_utils.dart' show PromptUtils;

--- a/lib/src/prompt_utils/prompt_utils.dart
+++ b/lib/src/prompt_utils/prompt_utils.dart
@@ -1,0 +1,36 @@
+import '../../prompt.dart';
+
+/// Reusable prompt helpers built on top of [Prompt].
+extension PromptUtils on Prompt {
+  /// Asks a yes/no question.
+  ///
+  /// Returns `null` when cancelled. Empty input uses [defaultValue] when set.
+  Future<bool?> confirm(String message, {bool? defaultValue}) async {
+    while (true) {
+      final answer = await text(_confirmMessage(message, defaultValue));
+      if (answer == null) return null;
+
+      final normalized = answer.trim().toLowerCase();
+      if (normalized.isEmpty && defaultValue != null) {
+        return defaultValue;
+      }
+      if (normalized == 'y' || normalized == 'yes') return true;
+      if (normalized == 'n' || normalized == 'no') return false;
+
+      message = 'Please answer yes or no';
+    }
+  }
+}
+
+String _confirmMessage(String message, bool? defaultValue) {
+  final label = _defaultConfirmLabel(defaultValue);
+  return label == null ? message : '$message ($label)';
+}
+
+String? _defaultConfirmLabel(bool? value) {
+  return switch (value) {
+    true => 'Y/n',
+    false => 'y/N',
+    null => null,
+  };
+}

--- a/test/prompt_utils_test.dart
+++ b/test/prompt_utils_test.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:coal/prompt.dart';
+import 'package:coal/prompt_utils.dart';
+import 'package:coal/readline.dart';
+import 'package:coal/utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('prompt utils', () {
+    test('confirm parses yes and no answers', () async {
+      await _expectConfirmAnswer(' y ', isTrue);
+      await _expectConfirmAnswer('yes', isTrue);
+      await _expectConfirmAnswer('n', isFalse);
+      await _expectConfirmAnswer('no', isFalse);
+    });
+
+    test('confirm uses defaults for empty answers', () async {
+      final yes = _PromptHarness();
+      addTearDown(yes.close);
+
+      final confirmed = yes.prompt.confirm('Continue', defaultValue: true);
+      await yes.pump();
+      yes.addText('\r');
+
+      expect(await confirmed, isTrue);
+      expect(
+        stripVTControlCharacters(yes.outputText),
+        contains('Continue (Y/n): '),
+      );
+
+      final no = _PromptHarness();
+      addTearDown(no.close);
+
+      final rejected = no.prompt.confirm('Continue', defaultValue: false);
+      await no.pump();
+      no.addText('\r');
+
+      expect(await rejected, isFalse);
+      expect(
+        stripVTControlCharacters(no.outputText),
+        contains('Continue (y/N): '),
+      );
+    });
+
+    test(
+      'confirm retries empty and invalid answers without a default',
+      () async {
+        final harness = _PromptHarness();
+        addTearDown(harness.close);
+
+        final answer = harness.prompt.confirm('Continue');
+        await harness.pump();
+        harness.addText('\rmaybe\ry\r');
+
+        expect(await answer, isTrue);
+        final output = stripVTControlCharacters(harness.outputText);
+        expect(output, contains('Continue: '));
+        expect(output, contains('Please answer yes or no: '));
+      },
+    );
+
+    test('confirm keeps defaults after invalid answers', () async {
+      final harness = _PromptHarness();
+      addTearDown(harness.close);
+
+      final answer = harness.prompt.confirm('Continue', defaultValue: false);
+      await harness.pump();
+      harness.addText('maybe\r\r');
+
+      expect(await answer, isFalse);
+      final output = stripVTControlCharacters(harness.outputText);
+      expect(output, contains('Continue (y/N): '));
+      expect(output, contains('Please answer yes or no (y/N): '));
+    });
+
+    test('confirm returns null when cancelled or input ends', () async {
+      final cancel = _PromptHarness();
+      addTearDown(cancel.close);
+
+      final cancelled = cancel.prompt.confirm('Continue');
+      await cancel.pump();
+      cancel.addBytes(<int>[0x03]);
+
+      expect(await cancelled, isNull);
+
+      final eof = _PromptHarness();
+      addTearDown(eof.close);
+
+      final ended = eof.prompt.confirm('Continue');
+      await eof.pump();
+      eof.endInput();
+
+      expect(await ended, isNull);
+    });
+
+    test('confirm does not swallow prompt errors', () async {
+      final harness = _PromptHarness();
+      addTearDown(harness.close);
+
+      final answer = harness.prompt.confirm('Continue');
+      await harness.pump();
+      harness.addError(StateError('boom'));
+
+      await expectLater(
+        answer,
+        throwsA(
+          isA<StateError>().having((error) => error.message, 'message', 'boom'),
+        ),
+      );
+    });
+  });
+}
+
+Future<void> _expectConfirmAnswer(String input, Matcher matcher) async {
+  final harness = _PromptHarness();
+  addTearDown(harness.close);
+
+  final answer = harness.prompt.confirm('Continue');
+  await harness.pump();
+  harness.addText('$input\r');
+  expect(await answer, matcher);
+}
+
+final class _PromptHarness {
+  _PromptHarness() {
+    final readline = Readline(input: _controller.stream, output: _output);
+    prompt = Prompt(readline: readline);
+  }
+
+  final _output = StringBuffer();
+  final _controller = StreamController<List<int>>();
+
+  late final Prompt prompt;
+  bool _closed = false;
+
+  String get outputText => _output.toString();
+
+  void addText(String text) {
+    addBytes(utf8.encode(text));
+  }
+
+  void addBytes(List<int> bytes) {
+    _controller.add(bytes);
+  }
+
+  void addError(Object error) {
+    _controller.addError(error);
+  }
+
+  void endInput() {
+    _controller.close();
+  }
+
+  Future<void> pump() async {
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    await prompt.close();
+    _controller.close();
+  }
+}


### PR DESCRIPTION
## Summary

- add package:coal/prompt_utils.dart with a narrow PromptUtils.confirm(...) extension
- document prompt utils usage in README and record the feature in CHANGELOG
- cover yes/no parsing, defaults, invalid retry behavior, cancellation/EOF, and prompt error propagation

Closes #15

## Validation

- dart format --set-exit-if-changed .
- dart analyze
- dart test test/prompt_utils_test.dart --reporter compact
- dart test --exclude-tags=script-runtime --reporter compact
- dart test --tags=script-runtime --reporter compact
- dart pub publish --dry-run (0 warnings)

## Review

- Subagent read-only architecture/code review found no P1/P2 blockers after the default-retention fix.