### PR TITLE
chore(release): prepare 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.1.0 - 2026-06-17
+
 - feat(prompt-utils): add a confirm helper.
 - feat(prompt): add basic text prompt flow.
 - feat(readline): add interactive line input handling.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: coal
 description: Composable utilities for Dart command-line apps.
-version: 0.0.7
+version: 0.1.0
 repository: https://github.com/medz/coal
 
 executables:


### PR DESCRIPTION
## Summary

- bump package version to 0.1.0
- move the accumulated unreleased entries into the 0.1.0 changelog section

## Validation

- dart format --set-exit-if-changed .
- dart analyze
- dart test --exclude-tags=script-runtime --reporter compact
- dart test --tags=script-runtime --reporter compact
- dart pub outdated
- dart pub publish --dry-run (0 warnings)

## Review

- Release readiness subagent recommended 0.1.0 and found no P2 blockers after the release-prep commit requirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.0
  * CHANGELOG updated with new release information and documented features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->